### PR TITLE
Corrected scipy installation using anaconda in windows 10

### DIFF
--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -131,14 +131,16 @@ Install dependencies (Linux / OS-X) ::
 
   $ conda config --add channels conda-forge 
   $ conda install numpy pytest pytest-runner gcc
-  $ conda install tifffile scipy matplotlib h5py astropy
+  $ conda install tifffile matplotlib h5py astropy
   $ conda install pillow shapely randomcolor pywavelets
+  $ conda install -c anaconda scipy
 
 Install dependencies (Windows) ::
 
   $ conda config --add channels conda-forge 
   $ conda install numpy pytest pytest-runner
-  $ conda install m2w64-toolchain tifffile scipy h5py astropy
+  $ conda install m2w64-toolchain tifffile h5py astropy
+  $ conda install -c anaconda scipy
   $ conda install matplotlib pillow shapely randomcolor pywavelets
 
 Get the ``storm-analysis`` source code using git ::

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -140,8 +140,8 @@ Install dependencies (Windows) ::
   $ conda config --add channels conda-forge 
   $ conda install numpy pytest pytest-runner
   $ conda install m2w64-toolchain tifffile h5py astropy
-  $ conda install -c anaconda scipy
   $ conda install matplotlib pillow shapely randomcolor pywavelets
+  $ conda install -c anaconda scipy
 
 Get the ``storm-analysis`` source code using git ::
 

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -131,9 +131,9 @@ Install dependencies (Linux / OS-X) ::
 
   $ conda config --add channels conda-forge 
   $ conda install numpy pytest pytest-runner gcc
-  $ conda install tifffile matplotlib h5py astropy
+  $ conda install tifffile scipy matplotlib h5py astropy
   $ conda install pillow shapely randomcolor pywavelets
-  $ conda install -c anaconda scipy
+
 
 Install dependencies (Windows) ::
 


### PR DESCRIPTION
Anaconda could not install scipy using "conda install m2w64-toolchain tifffile scipy".  Using "conda install -c anaconda scipy" works. 