### PR TITLE
Add an OS-X CI job

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -45,6 +45,42 @@ jobs:
       run: |
         pytest
 
+  # OS-X build. The runner is Apple Silicon, so this is what exercises the
+  # /opt/homebrew path in SConstruct - nothing had built this project on a
+  # Mac in years.
+  #
+  # The steps are deliberately the same ones doc/source/install.rst tells
+  # users to run. If this needs a workaround that the instructions do not
+  # mention, then the instructions are wrong and should be fixed instead.
+  macos:
+
+    runs-on: macos-latest
+    continue-on-error: true
+
+    steps:
+    - uses: actions/checkout@v7
+    - name: Set up Python
+      uses: actions/setup-python@v7
+      with:
+        python-version: "3.12"
+
+    - name: Install C dependencies
+      run: brew install fftw lapack
+
+    - name: Install Python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install pytest scons
+
+    - name: Build C libraries
+      run: scons
+
+    - name: Install python package
+      run: python -m pip install -e .
+
+    - name: Test with pytest
+      run: pytest
+
   # Windows build. This replaces the Appveyor job that was removed in 2023,
   # and produces the DLLs so that Windows users do not have to install a C
   # compiler themselves.

--- a/storm_analysis/sa_library/cs_decon_utilities_c.py
+++ b/storm_analysis/sa_library/cs_decon_utilities_c.py
@@ -16,9 +16,14 @@ import storm_analysis.sa_library.loadclib as loadclib
 cs_util = loadclib.loadCLibrary("cs_decon_utilities")
 
 # C interface definition
+# Note: label() takes seven arguments. Leaving one out of argtypes makes
+#       ctypes treat it as variadic, and on Apple Silicon variadic arguments
+#       are passed on the stack rather than in registers, so the callee reads
+#       garbage. It happens to work on x86-64, where the two conventions agree.
 cs_util.label.argtypes = [ndpointer(dtype=numpy.float64),
                           ndpointer(dtype=numpy.int32),
                           ctypes.c_double,
+                          ctypes.c_int,
                           ctypes.c_int,
                           ctypes.c_int,
                           ctypes.c_int]


### PR DESCRIPTION
Nothing has built this project on a Mac in years, and the Apple Silicon fix in d9450038 was written without a Mac to test it on. The runner is arm64, so this job is what actually exercises the new `/opt/homebrew` detection.

The steps are deliberately the ones `doc/source/install.rst` tells users to run, rather than a tuned-for-CI variant — if this needs something the docs do not mention, then the docs are wrong and the fix belongs in SConstruct or the instructions, not in the workflow.

Known risk: Homebrew's `lapack` is keg-only (`shadowed_by_macos` — macOS provides LAPACK in Accelerate.framework), so it is not symlinked into `<prefix>/lib` and `-llapack` may not resolve. `fftw` is not keg-only, so the prefix detection itself should be fine.

`continue-on-error` while it proves itself, exactly as the Windows job was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)