### PR TITLE
Build the C libraries as part of pip install

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -35,9 +35,6 @@ jobs:
         python -m pip install pytest
         python -m pip install scons
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: Build C libraries
-      run: |
-        scons
     - name: Install python package
       run: |
         python -m pip install -e .
@@ -71,9 +68,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install pytest scons
-
-    - name: Build C libraries
-      run: scons
 
     - name: Install python package
       run: python -m pip install -e .
@@ -113,11 +107,9 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install pytest scons build wheel
 
-    # FFTW and LAPACK are not installed on the runner, so this picks up the
-    # DLLs that are checked in under storm_analysis/c_libraries.
-    - name: Build C libraries
-      run: scons -Q compiler=mingw
-
+    # This builds the C libraries too, see _custom_build.py. FFTW and LAPACK
+    # are not installed on the runner, so the build picks up the DLLs that
+    # are checked in under storm_analysis/c_libraries.
     - name: Install python package
       run: python -m pip install -e .
 

--- a/_custom_build.py
+++ b/_custom_build.py
@@ -1,0 +1,49 @@
+"""Run the SCons build as part of the Python build.
+
+The C libraries are built by SCons rather than by setuptools, so without
+this they have to be built by hand before 'pip install .'. Getting that
+order wrong is easy and the result is confusing: the install succeeds, and
+then fails later when it tries to load a library that was never compiled.
+Re-running SCons afterwards does not fix an already installed copy either.
+
+See [tool.setuptools.cmdclass] in pyproject.toml for how this is wired in.
+"""
+import os
+import platform
+import subprocess
+import sys
+
+
+def runSCons():
+    """
+    Build the C libraries.
+
+    The 'scons' script is not reliably on PATH inside pip's isolated build
+    environment, so call the entry point it would have called. SCons itself
+    comes from [build-system] requires.
+    """
+    args = [sys.executable,
+            "-c", "from SCons.Script.Main import main; main()",
+            "-Q"]
+
+    # Windows has no default compiler the way the other platforms do, so
+    # SConstruct has to be told. Set SA_SCONS_COMPILER to use something
+    # other than mingw.
+    compiler = os.environ.get("SA_SCONS_COMPILER", "")
+    if (len(compiler) == 0) and (platform.system() == "Windows"):
+        compiler = "mingw"
+    if (len(compiler) > 0):
+        args.append("compiler=" + compiler)
+
+    print("Building C libraries:", " ".join(args), flush = True)
+    subprocess.check_call(args, cwd = os.path.dirname(os.path.abspath(__file__)))
+
+
+from setuptools.command.build_py import build_py as _build_py
+
+
+class build_py(_build_py):
+
+    def run(self):
+        runSCons()
+        super().run()

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -81,36 +81,32 @@ virtual environments is highly recommended. Two good resources are:
 
 .. note:: Link (2) above describes the best way to create the virtual environment on Windows in a way that they will work with PyQt5.
 
-Using setup.py
-~~~~~~~~~~~~~~
+Using pip
+~~~~~~~~~
 
 The C libraries are built using `SCons <http://scons.org/>`_.
 
-Basic installation ::
+pip builds the C libraries as part of the install, so this is a single step ::
   
   $ git clone https://github.com/ZhuangLab/storm-analysis.git
   $ cd storm-analysis
+  $ python -m pip install .
+
+This works the same way on Linux, OS-X and Windows. You still need a C
+compiler and the FFTW and LAPACK libraries; the install will fail if they
+cannot be found.
+
+.. note:: On Windows the build uses mingw. Set the ``SA_SCONS_COMPILER``
+   environment variable if you want SCons to use a different compiler.
+
+To build the C libraries on their own, without installing ::
+
   $ python -m pip install scons
   $ scons
-  $ python -m pip install .
-
-Linux / OS-X example ::
-  
-  $ cd storm-analysis
-  $ python -m pip install scons  
-  $ scons
-  $ python -m pip install .
-  
-Windows (mingw64) example ::
-
-  $ cd storm-analysis
-  $ python -m pip install scons  
-  $ scons -Q compiler=mingw
-  $ python -m pip install .
 
 `nuwen <https://nuwen.net/mingw.html>`_ is one source for mingw64. 
 
-.. note:: The OS-X build assumes that the lapack and fftw libraries are installed in the standard homebrew location, /usr/local/. If this is not the case you may need to edit storm-analysis/SConstruct.
+.. note:: The OS-X build looks for fftw and lapack under /opt/homebrew (Apple Silicon homebrew), /usr/local (Intel homebrew) and /opt/local (MacPorts). If yours are somewhere else, use ``scons prefix=/path/to/prefix``.
 
 .. note:: The OS-X build requires a fairly recent version of XCode, v8.1+? v8.3.3 is known to work.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ['setuptools>=61.0']
+requires = ['setuptools>=64.0', 'scons']
 build-backend = 'setuptools.build_meta'
 
 [project]
@@ -39,6 +39,10 @@ testpaths = [
 
 [tool.setuptools]
 packages = ["storm_analysis"]
+
+# Builds the C libraries as part of the Python build, see _custom_build.py.
+[tool.setuptools.cmdclass]
+build_py = "_custom_build.build_py"
 
 [project.optional-dependencies]
 test = [


### PR DESCRIPTION
Stacked on #52, so that CI here covers Linux, OS-X and Windows. Retarget to master once that merges.

The C libraries are built by SCons, which setuptools knows nothing about, so until now they had to be built by hand first. Getting the order wrong is easy and the result is confusing: `pip install .` before `scons` succeeds, and the package then fails when it tries to load a library that was never compiled. Running SCons afterwards does not fix an already-installed copy either, since a non-editable install copied the files at build time.

A `build_py` subclass in `_custom_build.py`, wired in through `[tool.setuptools.cmdclass]`, runs SCons before the normal build — no return to `setup.py`. Two details:

- It calls SCons' entry point through `sys.executable` rather than the `scons` script, which is not reliably on PATH inside pip's isolated build environment. SCons comes from `[build-system] requires` so it is available there at all.
- It passes `compiler=mingw` on Windows, which SConstruct needs and users previously had to remember. `SA_SCONS_COMPILER` overrides it.

Verified on Linux from a clean checkout with no `.so` files present: both `pip install .` and `pip install -e .` build and install all 29 libraries. Windows and OS-X are what this PR's CI run is for.

The explicit `scons` step is dropped from all three CI jobs, so they run the same single command the instructions now give rather than masking the hook.

### Behaviour change

`pip install .` now **fails** on a machine without a compiler and FFTW/LAPACK, where before it appeared to succeed. That is intended — a build error is easier to act on than a working install that does not work — but it is a real change for anyone who was relying on the old behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)