### PR TITLE
Version 2.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = 'setuptools.build_meta'
 
 [project]
 name = 'storm_analysis'
-version = '2.3'
+version = '2.4'
 dependencies = [
   'scons',
   'numpy',


### PR DESCRIPTION
Bumps the version so that the OS-X fixes made since 2.3 can be released.

2.3 was tagged before any of the OS-X work, so the current release is broken on Apple Silicon in two ways: it will not build (SConstruct looked for FFTW in the Intel homebrew location), and if that is worked around, deconvolution silently returns no localizations (a ctypes argtypes list was one argument short, which only misbehaves under Apple's arm64 variadic convention).

`__version__` in `storm_analysis/__init__.py` tracks the release date and 2.3 went out earlier today, so it already reads 2026.08.29 and needs no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)