### PR TITLE
Add CITATION.cff and .zenodo.json

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,44 @@
+{
+  "title": "storm-analysis",
+  "description": "Analysis code for STORM movies, developed in the Zhuang lab. Includes 3D-DAOSTORM, sCMOS, Spliner, Multiplane and several compressed-sensing deconvolution methods.",
+  "creators": [
+    {
+      "name": "Babcock, Hazen",
+      "orcid": "0000-0003-4835-3692"
+    },
+    {
+      "name": "Mary, Hadrien"
+    },
+    {
+      "name": "Heller, Evan"
+    },
+    {
+      "name": "Ikoma, Hayato"
+    },
+    {
+      "name": "Moffitt, Jeffrey"
+    },
+    {
+      "name": "Boettiger, Alistair"
+    },
+    {
+      "name": "Chandran, Gayatri"
+    }
+  ],
+  "license": "MIT",
+  "upload_type": "software",
+  "version": "2.4",
+  "keywords": [
+    "STORM",
+    "single-molecule localization microscopy",
+    "super-resolution",
+    "microscopy"
+  ],
+  "related_identifiers": [
+    {
+      "identifier": "https://github.com/ZhuangLab/storm-analysis",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    }
+  ]
+}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,37 @@
+# Note: .zenodo.json carries the same information for Zenodo, which reads it
+#       in preference to this file. Keep the two in step.
+cff-version: 1.2.0
+message: "If you use this software, please cite it using these metadata."
+title: "storm-analysis"
+abstract: "Analysis code for STORM movies, developed in the Zhuang lab. Includes 3D-DAOSTORM, sCMOS, Spliner, Multiplane and several compressed-sensing deconvolution methods."
+type: software
+authors:
+  - family-names: Babcock
+    given-names: Hazen
+    orcid: "https://orcid.org/0000-0003-4835-3692"
+  - family-names: Mary
+    given-names: Hadrien
+  - family-names: Heller
+    given-names: Evan
+  - family-names: Ikoma
+    given-names: Hayato
+  - family-names: Moffitt
+    given-names: Jeffrey
+  - family-names: Boettiger
+    given-names: Alistair
+  - family-names: Chandran
+    given-names: Gayatri
+version: "2.4"
+date-released: "2026-08-29"
+license: MIT
+repository-code: "https://github.com/ZhuangLab/storm-analysis"
+url: "https://storm-analysis.readthedocs.io/"
+identifiers:
+  - type: doi
+    value: "10.5281/zenodo.3528330"
+    description: "Concept DOI, always resolves to the latest version"
+keywords:
+  - STORM
+  - single-molecule localization microscopy
+  - super-resolution
+  - microscopy


### PR DESCRIPTION
Without these, Zenodo builds the author list from GitHub contributors, which gets it wrong in several ways. The current record for v2.2 reads:

| name | affiliation |
| --- | --- |
| Hazen Babcock | Proof Diagnostics |
| Hadrien Mary | Valence |
| Evan Heller | |
| Hayato Ikoma | @computational-imaging |
| **jeffmoffitt** | |
| Alistair Boettiger | Department of Developmental Biology, Stanford University |
| Gayatri Chandran | |

A GitHub username instead of a name, an organisation handle where an affiliation should be, ordering by commit count, no ORCIDs, and a title of `ZhuangLab/storm-analysis: Version 2.2`.

These two files set the author list and order explicitly, fix the name, give the project a real title and abstract, and record the concept DOI.

**Affiliations are deliberately omitted.** They change, and a file in a repository is a poor place to track where seven people currently work. ORCIDs are the durable identifier instead — Hazen Babcock's is included (checksum-validated and confirmed to resolve); the others can be added if they want them there.

`.zenodo.json` is generated from `CITATION.cff` rather than written by hand twice. Zenodo reads the JSON in preference to the `.cff`, so the two disagreeing would be worse than having only one. Their author lists are verified identical.

### Does not take effect on its own

Zenodo has not archived v2.3 or v2.4 — the latest version it holds is **v2.2 from 2023-02-26**, so the README's DOI badge currently resolves to three-year-old code. Until the GitHub integration at zenodo.org/account/settings/github/ is archiving again, this metadata sits in the repository unused. The existing v2.1/v2.2 records would also need editing on Zenodo directly; nothing here changes them retroactively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)