### PR TITLE
Do not claim a single license in the citation metadata

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -25,7 +25,6 @@
       "name": "Chandran, Gayatri"
     }
   ],
-  "license": "MIT",
   "upload_type": "software",
   "version": "2.4",
   "keywords": [

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -23,7 +23,10 @@ authors:
     given-names: Gayatri
 version: "2.4"
 date-released: "2026-08-29"
-license: MIT
+# No license field on purpose. Most of this project is MIT, but L1H and
+# spliner are under Harvard academic / non-commercial research licenses, so
+# a single SPDX identifier would misstate it. See the license files in the
+# individual directories.
 repository-code: "https://github.com/ZhuangLab/storm-analysis"
 url: "https://storm-analysis.readthedocs.io/"
 identifiers:


### PR DESCRIPTION
Follow-up to #55, which merged before this correction was pushed. Master currently says `license: MIT` in both citation files, and that is wrong.

Most of the project is MIT, but two directories are not:

| directory | license |
| --- | --- |
| `storm_analysis/L1H` | Harvard academic and non-commercial research use |
| `storm_analysis/spliner` | Harvard academic and non-commercial research use |

Spliner is one of the main analysis methods, not a corner case. Asserting MIT on the Zenodo record and in GitHub's citation panel tells people commercial use of it is permitted, which those licenses do not allow.

There is no SPDX identifier for "mostly MIT, two directories academic-only", so both files now omit the license field, with a comment in `CITATION.cff` pointing at the per-directory license files. Zenodo falls back to what it already infers rather than being told something incorrect.

The author lists in the two files are verified still identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)