### PR TITLE
Version 2.4.1

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -26,7 +26,7 @@
     }
   ],
   "upload_type": "software",
-  "version": "2.4",
+  "version": "2.4.1",
   "keywords": [
     "STORM",
     "single-molecule localization microscopy",

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -21,8 +21,8 @@ authors:
     given-names: Alistair
   - family-names: Chandran
     given-names: Gayatri
-version: "2.4"
-date-released: "2026-08-29"
+version: "2.4.1"
+date-released: "2026-08-30"
 # No license field on purpose. Most of this project is MIT, but L1H and
 # spliner are under Harvard academic / non-commercial research licenses, so
 # a single SPDX identifier would misstate it. See the license files in the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = 'setuptools.build_meta'
 
 [project]
 name = 'storm_analysis'
-version = '2.4'
+version = '2.4.1'
 dependencies = [
   'scons',
   'numpy',

--- a/storm_analysis/__init__.py
+++ b/storm_analysis/__init__.py
@@ -10,7 +10,7 @@ import matplotlib.pyplot as pyplot
 class SAException(Exception):
     pass
 
-__version__ = "2026.08.29"
+__version__ = "2026.08.30"
 
 # Maybe there is a builtin function that does this??
 def asciiString(value):


### PR DESCRIPTION
Identical to 2.4 apart from citation metadata.

`CITATION.cff` and `.zenodo.json` were added *after* v2.4 was tagged, and Zenodo reads `.zenodo.json` out of the tagged archive rather than from the default branch. So a release that predates those files gets the author list Zenodo derives from GitHub contributors — `jeffmoffitt`, scraped affiliations, commit-count ordering — which is exactly what those files exist to correct.

Re-publishing v2.4 would not have helped for the same reason, and moving a published tag onto later code would desync it from the wheel already attached to that release. Spending a patch version is the cheaper option.

Bumps all four places the version appears:

| file | change |
| --- | --- |
| `pyproject.toml` | `2.4` -> `2.4.1` |
| `storm_analysis/__init__.py` | `2026.08.29` -> `2026.08.30` (tracks release date) |
| `CITATION.cff` | version and date-released |
| `.zenodo.json` | regenerated from the .cff |

251 tests pass. No functional change — nobody on 2.4 needs to upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)