### PR TITLE
Fix five defects in the analysis pipeline

### DIFF
--- a/storm_analysis/dbscan/clusters_sa_h5py.py
+++ b/storm_analysis/dbscan/clusters_sa_h5py.py
@@ -12,6 +12,22 @@ import storm_analysis.sa_library.sa_h5py as saH5Py
 class SAH5Clusters(saH5Py.SAH5Py):
     """
     A sub-class of SAH5Py designed for use in clustering.
+
+    Note on localizations without a usable z:
+
+    The '3d' fitting model marks localizations whose measured widths are too
+    far from the wx/wy versus z calibration curve by setting their z to
+    -infinity, see sa_utilities/fitz.c. std_analysis.zCheck() then puts them
+    in category 9. getDataForClustering() drops them, because they are not
+    points in 3D and both dbscan_analysis.clusterStats() and the voronoi
+    equivalent compute a z center, a z extent and a radius of gyration from
+    whatever they are given. One such localization in a cluster is enough to
+    turn its z statistics into -infinity and its radius of gyration into nan,
+    including for a clustering that was run in 2D, since the radius of
+    gyration uses z whenever the field is present.
+
+    Note that this means they take no part in the clustering either, not even
+    a 2D one where their x and y would have been usable.
     """
     def addClusters(self, cluster_id, cluster_data):
         """
@@ -298,12 +314,15 @@ class SAH5Clusters(saH5Py.SAH5Py):
             c = numpy.zeros(total_locs, dtype = numpy.int32)
 
             fields = ['x', 'y', 'category']
-            
+
             # Check if the localizations have the 'z' field.
-            for f_num, locs in self.localizationsIterator(fields = fields):
-                if "z" in locs:
-                    fields.append('z')
-                break
+            #
+            # Note: this has to ask the file. Asking an iterator that was
+            #       given a field list returns only those fields, so testing
+            #       for 'z' in the result can never succeed.
+            #
+            if self.hasLocalizationsField("z"):
+                fields.append('z')
 
             start = 0
             for f_num, locs in self.localizationsIterator(fields = fields):
@@ -322,7 +341,22 @@ class SAH5Clusters(saH5Py.SAH5Py):
 
             cluster_data['frame'] = frame
             cluster_data['loc_id'] = loc_id
-            
+
+        # Drop anything without a usable z, see the class doc string. Data
+        # with no z field at all has z of zero here, which is finite, so
+        # nothing is removed in that case.
+        mask = numpy.isfinite(z)
+        n_removed = mask.size - numpy.count_nonzero(mask)
+        if (n_removed > 0):
+            print("Warning!", n_removed, "of", mask.size,
+                  "removed before clustering, they have no usable z value.")
+            x = x[mask]
+            y = y[mask]
+            z = z[mask]
+            c = c[mask]
+            for field in cluster_data:
+                cluster_data[field] = cluster_data[field][mask]
+
         return [x, y, z, c, cluster_data]
                              
     def getNClusters(self):

--- a/storm_analysis/sa_library/datawriter.py
+++ b/storm_analysis/sa_library/datawriter.py
@@ -39,8 +39,15 @@ def inferWriter(filename, width = None, height = None):
         raise IOError("only .dax and .tif are supported (case sensitive..)")
 
 def dummyDaxFile(name, x_size, y_size):
+    #
+    # Note that the frame is [y_size, x_size], not [x_size, y_size]. The
+    # convention in the module doc string is that a frame is indexed
+    # [height, width], and x_size is the width. The simulator works in the
+    # other order internally and transposes just before addFrame(), see
+    # simulate.py and the comment in simulator/camera.py.
+    #
     ddax = DaxWriter(name, width = x_size, height = y_size)
-    frame = numpy.ones((x_size, y_size))
+    frame = numpy.ones((y_size, x_size))
     ddax.addFrame(frame)
     ddax.close()
 

--- a/storm_analysis/sa_utilities/fitz.c
+++ b/storm_analysis/sa_utilities/fitz.c
@@ -108,9 +108,19 @@ double findBestZ(zfitData *zfit_data, double wx, double wy)
     }
   }
 
-  // distance cut-off here
+  /*
+   * Distance cut-off. Localizations that are too far from the calibration
+   * curve get -infinity rather than a value just below the z range.
+   *
+   * The marker has to survive two things. Drift correction is added to z
+   * after this runs, and a marker only 1 nm below z_min is hidden by any
+   * drift larger than that, so it has to be a value that addition cannot
+   * move. Tracks then average z over their localizations, and -infinity
+   * propagates through that average, so a track containing even one
+   * localization without a usable z is marked as well.
+   */
   if (best_d > zfit_data->cut_off){
-    rval = zfit_data->z_values[0] - 1.0;
+    rval = -INFINITY;
   }
   else {
     rval = best_z;

--- a/storm_analysis/sa_utilities/fitz_c.py
+++ b/storm_analysis/sa_utilities/fitz_c.py
@@ -77,7 +77,10 @@ def fitzRaw(h5_name, cutoff, wx_params, wy_params, z_min, z_max, z_step, wx_wy_f
     This processes the raw localizations.
 
     Note: Localizations whose wx/wy values are too far from the calibration
-          curve will be given a z value that is less than z_min.
+          curve are given a z value of -infinity, which std_analysis.zCheck()
+          then marks as category 9. It has to be -infinity and not a value
+          just below z_min, because drift correction is added to z after this
+          runs and would hide a small marker.
     """
     zfit_data = c_fitz.initialize(numpy.ascontiguousarray(wx_params),
                                   numpy.ascontiguousarray(wy_params),
@@ -108,8 +111,11 @@ def fitzTracks(h5_name, cutoff, wx_params, wy_params, z_min, z_max, z_step, wx_w
     """
     This processes the tracked localizations.
 
-    Note: Localizations whose wx/wy values are too far from the calibration
-          curve will be given a z value that is less than z_min.
+    Note: Tracks whose mean wx/wy values are too far from the calibration
+          curve are given a z value of -infinity, as in fitzRaw(). A track
+          that already has -infinity keeps it: that means at least one of its
+          localizations had no usable z, and averaging the widths can hide
+          that even though averaging the z values did not.
     """
     zfit_data = c_fitz.initialize(numpy.ascontiguousarray(wx_params),
                                   numpy.ascontiguousarray(wy_params),
@@ -131,6 +137,11 @@ def fitzTracks(h5_name, cutoff, wx_params, wy_params, z_min, z_max, z_step, wx_w
                 wx = pixel_size * 2.0 * locs[wx_field][i]/locs["track_length"][i]                    
                 wy = pixel_size * 2.0 * locs[wy_field][i]/locs["track_length"][i]
                 z_vals[i] = c_fitz.findBestZ(zfit_data, wx, wy) * 1.0e-3
+
+            # Keep the marker on tracks that already have one.
+            if "z" in locs:
+                z_vals[numpy.isneginf(locs["z"])] = -numpy.inf
+
             h5.addTrackData(z_vals, index, "z")
 
     c_fitz.cleanup(zfit_data)

--- a/storm_analysis/sa_utilities/hdf5_to_bin.py
+++ b/storm_analysis/sa_utilities/hdf5_to_bin.py
@@ -15,9 +15,45 @@ import os
 
 from xml.etree import ElementTree
 
+import numpy
+
 import storm_analysis.sa_library.i3dtype as i3dtype
 import storm_analysis.sa_library.sa_h5py as saH5Py
 import storm_analysis.sa_library.writeinsight3 as i3w
+
+
+#
+# A track stores most of its fields as the sum over the localizations in the
+# track, see sa_utilities/tracker.py. Only x, y and z are averaged for you.
+# These are the fields that have to be divided by the track length before they
+# mean anything, i.e. the ones that describe a single observation of the
+# molecule rather than a total over the track.
+#
+# 'height' and 'sum' are deliberately not in this list, they are reported as
+# totals over the track. This is what the Insight3 era averager did. Its
+# average_flag table in sa_utilities/avemlist.c, removed in b7470d4a, marked
+# HEIGHT and AREA as TOTAL, and only WIDTH, ASPECT and BACKG as AVERAGE.
+# Totaling the height is the older of the two, see 85a8fe90.
+#
+TRACK_MEAN_FIELDS = ["background", "error", "xsigma", "ysigma"]
+
+
+def normalizeTrackFields(tracks):
+    """
+    Return a copy of 'tracks' with the per observation fields converted from
+    sums to means. Without this a molecule that stayed on for ten frames is
+    exported ten times too wide, sitting on ten times the background.
+    """
+    normalized = dict(tracks)
+    if not "track_length" in tracks:
+        return normalized
+
+    length = tracks["track_length"].astype(numpy.float64)
+    for field in TRACK_MEAN_FIELDS:
+        if field in normalized:
+            normalized[field] = normalized[field]/length
+
+    return normalized
 
 
 def hdf5ToBin(hdf5_name, bin_name):
@@ -32,7 +68,7 @@ def hdf5ToBin(hdf5_name, bin_name):
         if h5.hasTracks():
             print("Converting tracks.")
             for tracks in h5.tracksIterator():
-                i3.addMultiFitMolecules(tracks, 1, nm_per_pixel)
+                i3.addMultiFitMolecules(normalizeTrackFields(tracks), 1, nm_per_pixel)
 
         # Convert localizations.
         else:

--- a/storm_analysis/sa_utilities/xyz_drift_correction.py
+++ b/storm_analysis/sa_utilities/xyz_drift_correction.py
@@ -162,6 +162,10 @@ def xyzDriftCorrection(hdf5_filename, drift_filename, step, scale, z_min, z_max,
         #
         # Do Z correlation if requested.
         #
+        # Note that dz and old_dz are in microns. zOffset() returns an offset
+        # in z bins, so convert as soon as we have it and not later, otherwise
+        # the paths that fall back on old_dz record a value in the wrong units.
+        #
         dz = old_dz
         if correct_z and xy_success:
 
@@ -172,21 +176,20 @@ def xyzDriftCorrection(hdf5_filename, drift_filename, step, scale, z_min, z_max,
 
             # Do z correlation, skipping empty images.
             if (numpy.sum(xyz_curr) > 0):
-                [corr, fit, dz, z_success] = imagecorrelation.zOffset(xyz_master, xyz_curr)
+                [corr, fit, dz_bins, z_success] = imagecorrelation.zOffset(xyz_master, xyz_curr)
             else:
-                [corr, fit, dz, z_success] = [0.0, 0.0, 0.0, False]
-            
-            # Update Values
-            if z_success:
-                old_dz = dz
-            else:
-                dz = old_dz
-            
-            dz = dz * (z_max - z_min)/float(z_bins)
+                [corr, fit, dz_bins, z_success] = [0.0, 0.0, 0.0, False]
 
+            # Update values. If we failed, use the last successful offset
+            # measurement, as we do for x and y.
             if z_success:
+                dz = dz_bins * (z_max - z_min)/float(z_bins)
+                old_dz = dz
+
                 h5_dc.setDriftCorrectionZ(-dz)
                 xyz_master += h5_dc.grid3D(z_min, z_max, drift_corrected = True)
+            else:
+                dz = old_dz
 
         z.append(-dz)
 

--- a/storm_analysis/test/test_clusters_sa_h5py.py
+++ b/storm_analysis/test/test_clusters_sa_h5py.py
@@ -156,6 +156,73 @@ def test_cl_sa_h5py_5():
         assert(numpy.allclose(cl_dict['frame'], numpy.array([1,1,1,1,3,3,3,3])))
 
 
+def test_cl_sa_h5py_z_is_loaded():
+    """
+    getDataForClustering() has to actually load z when the localizations
+    have it. It used to ask an iterator for ['x','y','category'] and then
+    test whether 'z' was in the result, which it never is, so z came back
+    as zeros and 3D clustering of a localizations file silently ran in 2D.
+    """
+    locs = {"category" : numpy.zeros(4, dtype = numpy.int32),
+            "x" : numpy.arange(4, dtype = numpy.float64),
+            "y" : numpy.arange(4, dtype = numpy.float64),
+            "z" : numpy.arange(4, dtype = numpy.float64) * 0.1}
+
+    h5_name = storm_analysis.getPathOutputTest("test_clusters_z.hdf5")
+    storm_analysis.removeFile(h5_name)
+
+    with saH5Py.SAH5Py(h5_name, is_existing = False) as h5:
+        h5.setMovieInformation(1,1,5,"")
+        h5.setPixelSize(100.0)
+        h5.addLocalizations(locs, 1)
+
+    with clSAH5Py.SAH5Clusters(h5_name) as cl_h5:
+        [x, y, z, c, cl_dict] = cl_h5.getDataForClustering()
+
+    assert(numpy.allclose(z, locs["z"]))
+    assert not (numpy.allclose(z, numpy.zeros(z.size)))
+
+
+def test_cl_sa_h5py_drops_invalid_z():
+    """
+    Localizations with no usable z, which the '3d' model marks with
+    -infinity, are dropped before clustering. One of them in a cluster is
+    enough to turn its z statistics into -infinity and its radius of
+    gyration into nan.
+
+    Everything getDataForClustering() returns has to stay the same length,
+    since addClusters() asserts that and the frame and loc_id arrays are
+    what map a cluster row back to its localization.
+    """
+    locs = {"category" : numpy.zeros(4, dtype = numpy.int32),
+            "x" : numpy.arange(4, dtype = numpy.float64),
+            "y" : numpy.arange(4, dtype = numpy.float64),
+            "z" : numpy.array([0.1, -numpy.inf, 0.3, 0.4])}
+
+    h5_name = storm_analysis.getPathOutputTest("test_clusters_bad_z.hdf5")
+    storm_analysis.removeFile(h5_name)
+
+    with saH5Py.SAH5Py(h5_name, is_existing = False) as h5:
+        h5.setMovieInformation(1,1,5,"")
+        h5.setPixelSize(100.0)
+        h5.addLocalizations(locs, 1)
+
+    with clSAH5Py.SAH5Clusters(h5_name) as cl_h5:
+        [x, y, z, c, cl_dict] = cl_h5.getDataForClustering()
+
+    assert (x.size == 3)
+    assert (numpy.all(numpy.isfinite(z)))
+    assert (numpy.allclose(x, numpy.array([0.0, 2.0, 3.0])))
+
+    # Every returned array, including the ones used to map back to the
+    # source localizations, stays the same length.
+    assert (y.size == 3)
+    assert (c.size == 3)
+    for field in cl_dict:
+        assert (cl_dict[field].size == 3), field
+    assert (numpy.allclose(cl_dict["loc_id"], numpy.array([0, 2, 3])))
+
+
 def test_cl_sa_h5py_6():
     """
     Test getting all of the tracks for clustering.

--- a/storm_analysis/test/test_dataio.py
+++ b/storm_analysis/test/test_dataio.py
@@ -167,8 +167,54 @@ def test_io_5():
     assert(numpy.allclose(data[0,:,:], rd.loadAFrame(0)))
 
     
+def test_io_6():
+    """
+    Test the dummyDaxFile() and singleFrameDax() helpers on a non-square
+    movie.
+
+    dummyDaxFile() built its frame as [x_size, y_size] while telling the
+    writer that x_size was the width, so addFrame() asserted on anything
+    that was not square. singleFrameDax(), immediately below it, has always
+    had this right.
+    """
+    movie_w = 16
+    movie_h = 8
+
+    ## dummyDaxFile.
+    movie_name = storm_analysis.getPathOutputTest("test_dataio_dummy.dax")
+
+    datawriter.dummyDaxFile(movie_name, movie_w, movie_h)
+
+    rd = datareader.inferReader(movie_name)
+    [mw, mh, ml] = rd.filmSize()
+
+    assert(mw == movie_w)
+    assert(mh == movie_h)
+    assert(ml == 1)
+
+    frame = rd.loadAFrame(0)
+    assert(frame.shape == (movie_h, movie_w))
+    assert(numpy.allclose(frame, numpy.ones((movie_h, movie_w))))
+
+    ## singleFrameDax, the same convention from the other side.
+    data = numpy.random.randint(0, 60000, (movie_h, movie_w)).astype(numpy.uint16)
+
+    movie_name = storm_analysis.getPathOutputTest("test_dataio_single.dax")
+
+    datawriter.singleFrameDax(movie_name, data)
+
+    rd = datareader.inferReader(movie_name)
+    [mw, mh, ml] = rd.filmSize()
+
+    assert(mw == movie_w)
+    assert(mh == movie_h)
+    assert(ml == 1)
+    assert(numpy.allclose(data, rd.loadAFrame(0)))
+
+    
 if (__name__ == "__main__"):
     test_io_1()
     test_io_2()
     test_io_3()
+    test_io_6()
     

--- a/storm_analysis/test/test_drift_correction.py
+++ b/storm_analysis/test/test_drift_correction.py
@@ -13,7 +13,7 @@ import storm_analysis.sa_utilities.xyz_drift_correction as xyzDriftCorrection
 import storm_analysis.test.verifications as veri
 
 
-def _test_drift_correction_1():
+def test_drift_correction_1():
     """
     This tests the whole process.
     """
@@ -52,6 +52,58 @@ def _test_drift_correction_1():
 
     if (diffs[3] > 0.03):
         raise Exception("Z drift correction error.")
+
+
+def test_drift_correction_1_xy_failure():
+    """
+    When an XY correlation fails the z offset for that bin falls back on the
+    last successful measurement. That fallback used to be recorded in z bin
+    units rather than microns, because the conversion sat inside the branch
+    that the failure skips, giving a spike of z_bins/(z_max - z_min) times
+    the real value. At the default binning that is 20x, which puts it well
+    outside the z range the data can even cover.
+    """
+    param_name = storm_analysis.getData("test/data/test_drift.xml")
+    parameters = params.ParametersCommon().initFromFile(param_name)
+
+    data_name = storm_analysis.getData("test/data/test_drift.hdf5")
+    h5_name = storm_analysis.getPathOutputTest("test_dc_xy_fail.hdf5")
+    storm_analysis.removeFile(h5_name)
+    shutil.copyfile(data_name, h5_name)
+
+    drift_output = storm_analysis.getPathOutputTest("test_drift_xy_fail.txt")
+    storm_analysis.removeFile(drift_output)
+
+    [min_z, max_z] = parameters.getZRange()
+
+    # Force one XY correlation to fail, part way through the movie so that
+    # there is an earlier successful z measurement to fall back on.
+    real_xy_offset = imagecorrelation.xyOffset
+    state = {"n" : 0}
+
+    def failing_xy_offset(*args, **kwds):
+        result = list(real_xy_offset(*args, **kwds))
+        state["n"] += 1
+        if (state["n"] == 4):
+            result[3] = False
+        return result
+
+    imagecorrelation.xyOffset = failing_xy_offset
+    try:
+        xyzDriftCorrection.xyzDriftCorrection(h5_name,
+                                              drift_output,
+                                              parameters.getAttr("frame_step"),
+                                              parameters.getAttr("d_scale"),
+                                              min_z,
+                                              max_z,
+                                              True)
+    finally:
+        imagecorrelation.xyOffset = real_xy_offset
+
+    # Every z value has to stay inside the range the localizations cover.
+    # In bin units the fallback lands around 1.4, against a range of +-0.5.
+    drift = numpy.loadtxt(drift_output)
+    assert (numpy.max(numpy.abs(drift[:,3])) < (max_z - min_z))
 
 
 def test_drift_correction_2():

--- a/storm_analysis/test/test_fitz_c.py
+++ b/storm_analysis/test/test_fitz_c.py
@@ -87,7 +87,11 @@ def test_fitz_c_2():
     # Check Z values.
     with saH5Py.SAH5Py(h5_name) as h5:
         locs = h5.getLocalizationsInFrame(1)
-        assert(numpy.allclose(locs["z"], min_z*numpy.ones(sx.size)-1.0e-3))
+
+        # Off the calibration curve, so no usable z. The marker is -infinity
+        # rather than a value just below min_z, because drift correction is
+        # added to z later and would hide a small marker.
+        assert(numpy.all(numpy.isneginf(locs["z"])))
         
     
 def test_fitz_c_3():
@@ -175,8 +179,61 @@ def test_fitz_c_4():
     # Check Z values.
     with saH5Py.SAH5Py(h5_name) as h5:
         for tracks in h5.tracksIterator():
-            assert(numpy.allclose(tracks["z"], min_z*numpy.ones(sx.size)-1.0e-3))
+            assert(numpy.all(numpy.isneginf(tracks["z"])))
             assert(numpy.allclose(tracks["category"], numpy.ones(sx.size)))
+
+
+def test_fitz_c_marker_survives_drift():
+    """
+    The 'no usable z' marker has to survive drift correction.
+
+    fitz runs before drift correction, and zCheck() reads drift corrected z,
+    so a marker of min_z - 1 nm was hidden by any z drift larger than 1 nm.
+    -infinity is not moved by adding an offset.
+    """
+    settings = storm_analysis.getData("test/data/test_3d_3d.xml")
+    parameters = params.ParametersDAO().initFromFile(settings)
+    [min_z, max_z] = parameters.getZRange()
+
+    h5_name = storm_analysis.getPathOutputTest("test_fitz_drift.hdf5")
+    storm_analysis.removeFile(h5_name)
+
+    with saH5Py.SAH5Py(h5_name, is_existing = False) as h5:
+        h5.setMovieInformation(64, 64, 1, "XYZZY")
+        h5.setPixelSize(100.0)
+        h5.addLocalizations({"x" : numpy.array([1.0, 2.0]),
+                             "y" : numpy.array([1.0, 2.0]),
+                             "z" : numpy.array([0.1, -numpy.inf]),
+                             "category" : numpy.zeros(2, dtype = numpy.int32)}, 0)
+        h5.setDriftCorrection(0, dx = 0.0, dy = 0.0, dz = 0.2)
+
+    # 200 nm of z drift, which would have buried a 1 nm marker completely.
+    with saH5Py.SAH5Py(h5_name) as h5:
+        locs = h5.getLocalizationsInFrame(0, drift_corrected = True)
+
+    assert (numpy.isneginf(locs["z"][1]))
+    assert (locs["z"][1] < min_z)
+    assert not (numpy.isneginf(locs["z"][0]))
+
+
+def test_fitz_c_marker_propagates_to_tracks():
+    """
+    A track that averages over several localizations, only some of which have
+    a usable z, has to be marked too. Averaging -infinity gives -infinity, and
+    fitzTracks() leaves an existing marker alone rather than recomputing a
+    plausible looking z from the mean widths.
+    """
+    import storm_analysis.sa_utilities.tracker as tracker
+
+    track = tracker.Track(category = 0, frame_number = 0, track_id = 0)
+    locs = {"x" : numpy.ones(3),
+            "y" : numpy.ones(3),
+            "z" : numpy.array([0.10, -numpy.inf, 0.12]),
+            "sum" : numpy.array([100.0, 100.0, 100.0])}
+    for i in range(3):
+        track.addLocalization(locs, i)
+
+    assert (numpy.isneginf(track.tz/track.tw))
 
 
 def test_fitz_c_5():

--- a/storm_analysis/test/test_hdf5_to_bin.py
+++ b/storm_analysis/test/test_hdf5_to_bin.py
@@ -72,7 +72,66 @@ def test_hdf5_to_bin_2():
     assert(numpy.allclose(i3_data['fr'], numpy.ones(10)))
 
     
+def test_hdf5_to_bin_track_normalization():
+    """
+    Tracks store most of their fields as sums over the localizations in the
+    track, so exporting them raw made a molecule that stayed on for ten
+    frames ten times as wide.
+
+    Width, aspect ratio and background must not depend on the track length.
+    'a' and 'h' must, they are the total photons and the total height over
+    the track, which is how the Insight3 era averager reported them.
+    """
+    [sx, sy] = [1.5, 2.0]
+    [height, background, photons] = [1000.0, 20.0, 5000.0]
+    pixel_size = 100.0
+
+    lengths = numpy.array([1, 3, 10], dtype = numpy.int32)
+    n = lengths.size
+
+    tracks = {"x" : numpy.arange(n, dtype = numpy.float64) + 10.0,
+              "y" : numpy.arange(n, dtype = numpy.float64) + 10.0,
+              "z" : numpy.zeros(n),
+              "category" : numpy.zeros(n, dtype = numpy.int32),
+              "frame_number" : numpy.ones(n, dtype = numpy.int32),
+              "track_id" : numpy.arange(n, dtype = numpy.int64),
+              "track_length" : lengths,
+              "xsigma" : lengths*sx,
+              "ysigma" : lengths*sy,
+              "height" : lengths*height,
+              "background" : lengths*background,
+              "sum" : lengths*photons}
+
+    h5_name = storm_analysis.getPathOutputTest("test_h5_to_bin_norm.hdf5")
+    storm_analysis.removeFile(h5_name)
+
+    with saH5Py.SAH5Py(h5_name, is_existing = False) as h5:
+        h5.addMetadata("<settings/>")
+        h5.setMovieInformation(256, 256, 10, "XYZZY")
+        h5.setPixelSize(pixel_size)
+        h5.addLocalizations({"x" : numpy.zeros(1), "y" : numpy.zeros(1)}, 0)
+        h5.addTracks(tracks)
+
+    i3_name = storm_analysis.getPathOutputTest("test_h5_to_bin_norm.bin")
+    storm_analysis.removeFile(i3_name)
+    hdf5ToBin.hdf5ToBin(h5_name, i3_name)
+
+    i3_data = readinsight3.loadI3File(i3_name, verbose = False)
+
+    # Insight3 widths are 2 * sigma, in nanometers.
+    [wx, wy] = [2.0*sx*pixel_size, 2.0*sy*pixel_size]
+
+    assert(numpy.allclose(i3_data['w'], numpy.sqrt(wx*wy)*numpy.ones(n)))
+    assert(numpy.allclose(i3_data['ax'], (wy/wx)*numpy.ones(n)))
+    assert(numpy.allclose(i3_data['bg'], background*numpy.ones(n)))
+
+    # Totals, so these two do scale with the track length.
+    assert(numpy.allclose(i3_data['a'], lengths*photons))
+    assert(numpy.allclose(i3_data['h'], lengths*height))
+
+
 if (__name__ == "__main__"):
     test_hdf5_to_bin_1()
     test_hdf5_to_bin_2()
+    test_hdf5_to_bin_track_normalization()
 

--- a/storm_analysis/test/verifications.py
+++ b/storm_analysis/test/verifications.py
@@ -43,10 +43,17 @@ def verifyNumberLocalizations(h5_name):
 def verifyZWasCalculated(h5_name):
     """
     Return the true if all the Z values are not exactly identical.
+
+    Localizations that fitz could not assign a z to are marked with
+    -infinity, so ignore those. They are not calculated z values, and one
+    of them would turn the standard deviation into a nan.
     """
     locs = None
     with saH5Py.SAH5Py(h5_name) as h5:
         locs = h5.getLocalizations(fields = ["z"])
-    return (numpy.std(locs["z"]) > 1.0e-6)
+    z = locs["z"][numpy.isfinite(locs["z"])]
+    if (z.size == 0):
+        return False
+    return (numpy.std(z) > 1.0e-6)
 
 


### PR DESCRIPTION
Five defects found while auditing the pipeline around the fitters — the file
readers and writers, drift correction, localization linking and the wx/wy to z
calculation. Each commit is one issue, with a regression test that fails on its
parent commit.

### `2a02fc1c` Record z drift in microns when an XY correlation fails

The microns-per-bin conversion sat inside the branch that is skipped when the
XY correlation fails, so the fallback z drift was recorded in bin units. On the
test data that is 1.371 where 0.069 um was correct, a spike larger than the
entire z range.

### `0377f488` Mark localizations with no usable z with -infinity

`fitz` marked a failed z fit with `z_min - 1 nm`. That marker is written before
drift correction and the check that acts on it reads drift-corrected z, so any
z drift above 1 nm hides it. At 200 nm of drift the reject reads as an ordinary
-0.301 um and is kept. `-infinity` survives drift correction and track
averaging, so a track that averages over even one bad localization is still
marked.

### `676a52fd` Load z for clustering, and drop localizations that have none

`getDataForClustering()` probed for a z field in a way that could never
succeed, so 3D clustering of localizations has always silently run in 2D.
Fixing that exposed the `-infinity` markers to the clustering code, so
localizations with no usable z are now filtered out with a warning that says
how many were removed.

### `2e43489b` Normalize track fields when exporting to Insight3

Tracks store most of their fields as sums over the localizations in the track.
`hdf5ToBin()` handed the raw sums to `createFromMultiFit()`, which derives a
width from them, so a molecule that stayed on for ten frames was exported ten
times too wide on ten times the background. Background, error, xsigma and
ysigma are now divided by the track length. `height` and `sum` stay totals,
matching what `avemlist.c` did before it was removed.

### `0359d969` Build the dummy dax frame as [height, width]

`dummyDaxFile()` told the writer that `x_size` was the width, which is right,
then built its frame as `[x_size, y_size]`, which is not, so it raised
`AssertionError` on any movie that was not square. The `DaxWriter()` call is
the half that was already correct — `Simulate.simulate()` passes width and
height the same way and transposes just before writing.

---

Full test suite passes, 270 tests.
