### PR TITLE
Remove dead and inconsistent code

### DIFF
--- a/storm_analysis/sa_library/dao_fit.c
+++ b/storm_analysis/sa_library/dao_fit.c
@@ -1265,17 +1265,12 @@ fitData* daoInitialize(double *rqe, double *scmos_calibration, double tol, int i
   mFitInitializeROIIndexing(fit_data, roi_size);
 
   /*
-   * I thought that even/odd might need different offsets, but based on some testing
-   * it looks like the optimal offset is pretty similar / the same for both.
+   * I thought that even/odd ROI sizes might need different offsets, but based
+   * on some testing it looks like the optimal offset is pretty similar / the
+   * same for both, so roi_size%2 is deliberately not consulted here.
    */
-  if((roi_size%2)==0){
-    fit_data->xoff = 0.5*((double)roi_size) - 1.0;
-    fit_data->yoff = 0.5*((double)roi_size) - 1.0;
-  }
-  else{
-    fit_data->xoff = 0.5*((double)roi_size) - 1.0;
-    fit_data->yoff = 0.5*((double)roi_size) - 1.0;
-  }
+  fit_data->xoff = 0.5*((double)roi_size) - 1.0;
+  fit_data->yoff = 0.5*((double)roi_size) - 1.0;
 
   fit_data->fit_model = (daoFit *)malloc(sizeof(daoFit));
   dao_fit = (daoFit *)fit_data->fit_model;  

--- a/storm_analysis/sa_library/dao_fit_c.py
+++ b/storm_analysis/sa_library/dao_fit_c.py
@@ -222,8 +222,6 @@ def loadDaoFitC():
                                        ctypes.c_double,
                                        ctypes.c_double]
     
-    daofit.daoInitializeZ.argtypes = [ctypes.c_void_p]
-    
     daofit.daoInitializeZ.argtypes = [ctypes.c_void_p,
                                       ndpointer(dtype=numpy.float64), 
                                       ndpointer(dtype=numpy.float64),

--- a/storm_analysis/sa_library/multi_fit.c
+++ b/storm_analysis/sa_library/multi_fit.c
@@ -1929,12 +1929,12 @@ void mFitUpdate(peakData *peak)
   double dx,dy;
   
   dx = peak->params[XCENTER] - peak->xi;
-  if((dx<-0.5)||(dx>1.5)){
+  if((dx<(0.5-HYSTERESIS))||(dx>(0.5+HYSTERESIS))){
     peak->xi = (int)floor(peak->params[XCENTER]);
   }
 
   dy = peak->params[YCENTER] - peak->yi;
-  if((dy<-0.5)||(dy>1.5)){
+  if((dy<(0.5-HYSTERESIS))||(dy>(0.5+HYSTERESIS))){
     peak->yi = (int)floor(peak->params[YCENTER]);
   }
 }

--- a/storm_analysis/sa_library/multi_fit.h
+++ b/storm_analysis/sa_library/multi_fit.h
@@ -171,7 +171,6 @@ void mFitGetResidual(fitData *, double *);
 int mFitGetUnconverged(fitData *);
 fitData *mFitInitialize(double *, double *, double, int, int);
 void mFitInitializeROIIndexing(fitData *, int);
-void mFitIterateOriginal(fitData *);
 void mFitIterateLM(fitData *);
 void mFitNewBackground(fitData *, double *);
 void mFitNewImage(fitData *, double *);

--- a/storm_analysis/sa_library/multi_fit.h
+++ b/storm_analysis/sa_library/multi_fit.h
@@ -34,7 +34,7 @@
 #define CONVERGED 1
 #define ERROR 2
 
-#define HYSTERESIS 0.6 /* In order to move the AOI or change it's size,
+#define HYSTERESIS 1.0 /* In order to move the AOI or change it's size,
 			  the new value must differ from the old value
 			  by at least this much (<= 0.5 is no hysteresis). */
 

--- a/storm_analysis/sa_library/multi_fit.h
+++ b/storm_analysis/sa_library/multi_fit.h
@@ -181,6 +181,7 @@ double mFitPeakFgSum(fitData *, peakData *);
 double mFitPeakSum(fitData *, peakData *);
 void mFitRecenterPeaks(fitData *);
 void mFitRemoveErrorPeaks(fitData *);
+void mFitRemoveRunningPeaks(fitData *);
 void mFitResetPeak(fitData *, int);
 void mFitSetPeakStatus(fitData *, int32_t *);
 int mFitSolve(double *, double *, int);

--- a/storm_analysis/spliner/cubic_spline.c
+++ b/storm_analysis/spliner/cubic_spline.c
@@ -206,9 +206,11 @@ double dxfAt3D(splineData *spline_data, int zc, int yc, int xc)
 {
   double yv;
 
-  xc = rangeCheckI("dxfAt3D,xc", xc, 0, spline_data->xsize);
-  yc = rangeCheckI("dxfAt3D,yc", yc, 0, spline_data->ysize);
-  zc = rangeCheckI("dxfAt3D,zc", zc, 0, spline_data->zsize);
+  if(RANGECHECK){
+    xc = rangeCheckI("dxfAt3D,xc", xc, 0, spline_data->xsize);
+    yc = rangeCheckI("dxfAt3D,yc", yc, 0, spline_data->ysize);
+    zc = rangeCheckI("dxfAt3D,zc", zc, 0, spline_data->zsize);
+  }
 
   yv = dot(&(spline_data->aij[(xc*(spline_data->ysize*spline_data->zsize)+yc*spline_data->zsize+zc)*64]), spline_data->delta_dxf, 64);
 


### PR DESCRIPTION
Six items with no behavioural effect on any current code path, listed
because each one costs a reader time working out whether it matters. One
commit per issue.

Nothing here can carry a regression test, so where a change touches C the
evidence is a byte-identical object file rather than a passing suite.

### `413d2c12`, `e9ffba5b` Make multi_fit.h an accurate index

The header was wrong in both directions at once.
`mFitRemoveRunningPeaks()` is defined, exported and called from Python
through ctypes, but was the one `mFit*` function missing a declaration.
`mFitIterateOriginal()` was declared but has had no definition since
`a19f27d4` removed it in 2018. With both fixed, every definition in
`multi_fit.c` has a declaration and every declaration has a definition,
38 each way.

### `cb24ec83` Give HYSTERESIS its real value and use it

`HYSTERESIS` was defined as 0.6 and never referenced, while `mFitUpdate()`
recentred AOIs using two literals. Reading the constant as its comment
describes it, `|dx - 0.5| > HYSTERESIS`, the literals correspond to a value
of 1.0, not 0.6 — so hysteresis is live and the constant simply carried the
wrong number. Sets it to 1.0 and writes the bounds in terms of it.

`multi_fit.o` is byte identical before and after.

### `863f51bc` Guard dxfAt3D's range checks with RANGECHECK

Its six siblings wrap their `rangeCheckI()` calls in `if(RANGECHECK)`;
`dxfAt3D` called them unconditionally, so turning range checking off for
speed left this one function still paying. Compiled with `RANGECHECK 0`,
`dxfAt3D` goes from 46 instructions to 17 and its three message strings
disappear from the object.

`cubic_spline.o` is byte identical with `RANGECHECK 1`.

### `ff68de75` Collapse the identical if/else in daoInitialize

Both branches of `if((roi_size%2)==0)` were byte identical. The comment
above them explains why — the author tested even and odd ROI sizes and
found the same offset optimal — so this keeps the explanation and drops the
branch that does not branch.

`dao_fit.o` is byte identical before and after; gcc was already collapsing
it.

### `48fcac6c` Remove the dead daoInitializeZ argtypes assignment

`argtypes` was set twice two lines apart, the first immediately overwritten.
The survivor is the correct five-argument version matching `dao_fit.h:75`
and the call site. A scan of every `*_c.py` wrapper confirms this was the
only such case.

---

Full test suite passes, 277 tests.
