### PR TITLE
Build the documentation without warnings

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -64,7 +64,7 @@ release = '2.0'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -94,7 +94,10 @@ html_theme = 'alabaster'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+#
+# There are none, so this is empty. Add '_static' back, and create the
+# directory, if custom static files are ever wanted.
+html_static_path = []
 
 
 # -- Options for HTMLHelp output ------------------------------------------


### PR DESCRIPTION
`sphinx-build` emitted two warnings, both from settings `sphinx-quickstart`
wrote and nobody revisited since:

```
WARNING: Invalid configuration value found: 'language = None'. Update your
         configuration to a valid language code. Falling back to 'en'.
WARNING: html_static_path entry '_static' does not exist
```

`language = None` was the old way to say "not translated". Newer Sphinx wants
a language code and falls back to `'en'` anyway, so this says `'en'`.

`doc/source/_static` has never existed and is not ignored — it was simply
never created. There are no custom static files, so this empties
`html_static_path` rather than adding an empty directory whose only purpose
would be to stop the warning. A comment says how to put it back if custom CSS
is ever wanted.

### The output is unchanged

Building before and after gives identical file lists, and the only file that
differs at all is `.doctrees/environment.pickle`, which is Sphinx's own build
cache and records the config. Every html, css and js file is byte identical.
`_static` in the *output* still contains `alabaster.css` and the rest, since
those come from the theme rather than from `html_static_path`.

`sphinx-build` now reports `build succeeded.` with no warnings.

Nothing in the test suite or in `pyproject.toml` refers to `doc/`, and Sphinx
is not a dependency of the package, so this cannot affect the analysis code.
