### PR TITLE
Use int32_t where Python passes an int32 array

### DIFF
--- a/storm_analysis/L1H/homotopy_general.c
+++ b/storm_analysis/L1H/homotopy_general.c
@@ -25,6 +25,7 @@
  */
 
 /* Include */
+#include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <math.h>
@@ -300,7 +301,7 @@ void computeG3(void)
  *
  * vis - user supplied storage for the visited vector.
  */
-void getVisited(int *vis)
+void getVisited(int32_t *vis)
 {
   int i;
 

--- a/storm_analysis/L1H/homotopy_imagea_common.c
+++ b/storm_analysis/L1H/homotopy_imagea_common.c
@@ -5,6 +5,7 @@
  */
 
 /* Include */
+#include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>
@@ -61,7 +62,7 @@ void finishUp(void)
  *
  * returns - number of peaks that were found.
  */
-int getPeaks(double *hres, double *peak_x, double *peak_y, double *peak_i, int *peak_c, int max_peaks)
+int getPeaks(double *hres, double *peak_x, double *peak_y, double *peak_i, int32_t *peak_c, int max_peaks)
 {
   int i,j,n,o_size,t1;
   double xt,yt,t,inv_scale;

--- a/storm_analysis/L1H/homotopy_imagea_common.h
+++ b/storm_analysis/L1H/homotopy_imagea_common.h
@@ -9,11 +9,13 @@
 #ifndef HOMOTOPY_IMAGEA_COMMON_H
 #define HOMOTOPY_IMAGEA_COMMON_H
 
+#include <stdint.h>
+
 /* Function Declarations */
 void analyzeImage(double *, double *);
 void closeFile(void);
 void finishUp(void);
-int getPeaks(double *, double *, double *, double *, int *, int);
+int getPeaks(double *, double *, double *, double *, int32_t *, int);
 int openFile(char *);
 int saveHighRes(double *, int);
 void setImageParameters(double *, int, int, int, double, int, int, int, int, int);

--- a/storm_analysis/dbscan/dbscan.c
+++ b/storm_analysis/dbscan/dbscan.c
@@ -66,7 +66,7 @@ typedef struct
 // dbscan specific
 void appendN(intArr *, intArr *);
 intArr* createIntArr(int);
-void dbscan(float *, float *, float *, int *, int *, int, float, int, int);
+void dbscan(float *, float *, float *, int32_t *, int32_t *, int, float, int, int);
 int expandCluster(intArr *, int, float, int, int);
 void mergeN(intArr *, intArr *);
 intArr* regionQuery(int *, int, int, int, float);
@@ -74,8 +74,8 @@ intArr* regionQueryKD(int *, int, int, int, float);
 
 // additional
 void clusterSize(int *, int *, int, int);
-void locClSize(int *, int *, int, int);
-void recategorize(int *, int *, int, int, int);
+void locClSize(int32_t *, int32_t *, int, int);
+void recategorize(int32_t *, int32_t *, int, int, int);
 
 
 /* Global Variables */
@@ -166,7 +166,7 @@ intArr* createIntArr(int n)
  * min_points - minimum number of points in a cluster.
  * verbose - print cluster information as we go.
  */
-void dbscan(float *db_x, float *db_y, float *db_z, int *db_cat, int *db_l, int db_nsize, float eps, int min_points, int verbose)
+void dbscan(float *db_x, float *db_y, float *db_z, int32_t *db_cat, int32_t *db_l, int db_nsize, float eps, int min_points, int verbose)
 {
   int i,cluster_size,cn,counts,cur_cat;
   intArr *N;
@@ -535,7 +535,7 @@ void clusterSize(int *counts, int *cl_id, int cl_size, int max_id)
  * cl_size - size of cl_counts (and cl_id).
  * max_id - maximum cluster id number.
  */
-void locClSize(int *cl_counts, int *cl_id, int cl_size, int max_id)
+void locClSize(int32_t *cl_counts, int32_t *cl_id, int cl_size, int max_id)
 {
   int i;
   int *counts;
@@ -562,7 +562,7 @@ void locClSize(int *cl_counts, int *cl_id, int cl_size, int max_id)
  * max_id - maximum cluster id number.
  * min_size - minimum acceptable cluster size.
  */
-void recategorize(int *cl_id, int *category, int cl_size, int max_id, int min_size)
+void recategorize(int32_t *cl_id, int32_t *category, int cl_size, int max_id, int min_size)
 {
   int i;
   int *counts;

--- a/storm_analysis/frc/frc.c
+++ b/storm_analysis/frc/frc.c
@@ -18,12 +18,13 @@
  */
 
 /* Include */
+#include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <math.h>
 
 /* Function Declarations */
-void calc_frc(double *, double *, double *, int *, int, int);
+void calc_frc(double *, double *, double *, int32_t *, int, int);
 
 /*
  * calc_frc()
@@ -42,7 +43,7 @@ void calc_frc(double *, double *, double *, int *, int, int);
  * y_size - Size of the FFT array in y (arr.shape[0]).
  * x_size - Size of the FFT array in x (arr.shape[1]).
  */
-void calc_frc(double *fft1, double *fft2, double *frc, int *frc_counts, int y_size, int x_size)
+void calc_frc(double *fft1, double *fft2, double *frc, int32_t *frc_counts, int y_size, int x_size)
 {
   int cx,cy,dx,dy,i,j,q;
   int real,ima;

--- a/storm_analysis/sa_library/cs_decon_utilities.c
+++ b/storm_analysis/sa_library/cs_decon_utilities.c
@@ -9,14 +9,15 @@
  */
 
 /* Include */
+#include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>
 
 /* Function Declarations */
 int isMaxima(double *, int, int, int, int, int, int);
-int label(double *, int *, double, int, int, int, int);
+int label(double *, int32_t *, double, int, int, int, int);
 void labelImage(double *, int *, double, int, int, int, int, int, int, int);
-void moments(double *, double *, int *, int, int, int, int);
+void moments(double *, double *, int32_t *, int, int, int, int);
 
 /* Functions */
 
@@ -83,7 +84,7 @@ int isMaxima(double *image, int ci, int cj, int ck, int x_size, int y_size, int 
  *
  * Returns the number of unique labels.
  */
-int label(double *image, int *labels, double threshold, int margin, int x_size, int y_size, int z_size)
+int label(double *image, int32_t *labels, double threshold, int margin, int x_size, int y_size, int z_size)
 {
   int i,j,k,t;
   int cur_label;
@@ -170,7 +171,7 @@ void labelImage(double *image, int *labels, double threshold, int cur_label, int
  * y_size - Image size in y.
  * z_size - Image size in z.
  */
-void moments(double *image, double *peaks, int *labels, int counts, int x_size, int y_size, int z_size)
+void moments(double *image, double *peaks, int32_t *labels, int counts, int x_size, int y_size, int z_size)
 {
   int i,j,k,l,t;
 

--- a/storm_analysis/sa_library/grid.c
+++ b/storm_analysis/sa_library/grid.c
@@ -24,7 +24,7 @@
 
 void grid2D(int32_t *, int32_t *, int32_t *, int, int, int);
 void grid3D(int32_t *, int32_t *, int32_t *, int32_t *, int, int, int, int);
-void grid3DZInclusive(int *, int *, int *, int *, int, int, int, int);
+void grid3DZInclusive(int32_t *, int32_t *, int32_t *, int32_t *, int, int, int, int);
 
 /*
  * grid2D()
@@ -94,7 +94,7 @@ void grid3D(int32_t *grid, int32_t *i_x, int32_t *i_y, int32_t *i_z, int x_size,
  * z_size - grid size in z.
  * n_x - number of x (and y,z) locations.
  */
-void grid3DInclusize(int *grid, int *i_x, int *i_y, int *i_z, int x_size, int y_size, int z_size, int n_x)
+void grid3DZInclusive(int32_t *grid, int32_t *i_x, int32_t *i_y, int32_t *i_z, int x_size, int y_size, int z_size, int n_x)
 {
   int i,x,y,z;
 

--- a/storm_analysis/sa_library/grid.c
+++ b/storm_analysis/sa_library/grid.c
@@ -18,11 +18,12 @@
  */
 
 /* Include */
+#include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>
 
-void grid2D(int *, int *, int *, int, int, int);
-void grid3D(int *, int *, int *, int *, int, int, int, int);
+void grid2D(int32_t *, int32_t *, int32_t *, int, int, int);
+void grid3D(int32_t *, int32_t *, int32_t *, int32_t *, int, int, int, int);
 void grid3DZInclusive(int *, int *, int *, int *, int, int, int, int);
 
 /*
@@ -37,7 +38,7 @@ void grid3DZInclusive(int *, int *, int *, int *, int, int, int, int);
  * y_size - grid size in y.
  * n_x - number of x (and y) locations.
  */
-void grid2D(int *grid, int *i_x, int *i_y, int x_size, int y_size, int n_x)
+void grid2D(int32_t *grid, int32_t *i_x, int32_t *i_y, int x_size, int y_size, int n_x)
 {
   int i,x,y;
 
@@ -64,7 +65,7 @@ void grid2D(int *grid, int *i_x, int *i_y, int x_size, int y_size, int n_x)
  * z_size - grid size in z.
  * n_x - number of x (and y,z) locations.
  */
-void grid3D(int *grid, int *i_x, int *i_y, int *i_z, int x_size, int y_size, int z_size, int n_x)
+void grid3D(int32_t *grid, int32_t *i_x, int32_t *i_y, int32_t *i_z, int x_size, int y_size, int z_size, int n_x)
 {
   int i,x,y,z;
 


### PR DESCRIPTION
Fixes #27.

The issue asked for `int32_t` instead of `int` "in many places". The places
that matter turn out to be identifiable rather than a matter of taste, and
there are ten of them, not the 130 that a raw count of `int *` suggests.

C-to-C calls do not care what `sizeof(int)` is — the compiler is
self-consistent — and a `ctypes.c_int` scalar matches a C `int` at any size.
The assumption only bites where Python hands C a numpy `int32` buffer and C
reinterprets it as `int[]`, because `ctypes` checks the dtype on the Python
side only. **A mismatch there is silent memory corruption, not an error.**

Scanning every `*_c.py` argtypes block against the C declarations, Python
passes an `int32` array to 24 functions. 14 already used `int32_t`, all of
them in `multi_fit.c` and `ia_utilities.c` — the core was converted at some
point and the rest was not, which is why the tree currently holds two
conventions with no way to tell which is intended.

### `19199451` converts the remaining ten

| file | function | parameters |
| --- | --- | --- |
| `frc/frc.c` | `calc_frc` | `frc_counts` |
| `dbscan/dbscan.c` | `dbscan` | `db_cat`, `db_l` |
| | `locClSize` | `cl_counts`, `cl_id` |
| | `recategorize` | `cl_id`, `category` |
| `L1H/homotopy_general.c` | `getVisited` | `vis` |
| `L1H/homotopy_imagea_common.c` | `getPeaks` | `peak_c` |
| `sa_library/grid.c` | `grid2D` | `grid`, `i_x`, `i_y` |
| | `grid3D` | `grid`, `i_x`, `i_y`, `i_z` |
| `sa_library/cs_decon_utilities.c` | `label` | `labels` |
| | `moments` | `labels` |

None has a caller in C, so each change is a declaration and a definition with
no ripple. The other 120 `int *` parameters never cross the ctypes boundary
and are left alone.

**Nothing changes today, and provably so.** `int32_t` is a typedef for `int`
on every platform this package supports, LP64 and LLP64 alike, so compiling
each file before and after gives byte-identical objects — six checksums are
in the commit message. That identity is also why the compiler cannot check
this work: with `int32_t` and `int` the same type, a wrong conversion
produces no diagnostic. The check is the scan.

Note there are two functions named `getPeaks`. The one taking an `int32`
array is in L1H. `decon_storm/mlem_sparse.c` has another whose `int *n` is an
output count passed as `byref(c_int())`, so it is not a boundary case, and
that file is not in SConstruct in any event. A scan that keys on function
name must report every definition, not the first, or it hides one behind the
other.

### `849e4fa3` fixes a function that matched nothing

`grid.c` declared `grid3DZInclusive()` and documented it under that name,
then defined `grid3DInclusize()` — declared-without-definition and
defined-without-declaration at once, wrong since `6a486010`. Nothing calls
it. Renamed to match the declaration and the comment, and given the same
`int32_t` treatment as its two siblings so the file does not keep one
function on the old convention.

Verified by symbol table rather than checksum, since a rename changes the
symbol: exactly one line differs, at the same address, and the disassembly is
identical instruction for instruction once that name is normalized.

---

Full test suite passes, 278 tests. No new compiler warnings.
