### PR TITLE
Fix names that do not resolve, and drop Python 2

### DIFF
--- a/storm_analysis/L1H/setup_A_matrix.py
+++ b/storm_analysis/L1H/setup_A_matrix.py
@@ -12,7 +12,6 @@ import os
 import pickle
 import scipy.io
 from scipy.interpolate import griddata
-import sys
 
 
 def createCoordinates(inner_size, scale, boundary_scale, pad = [0,0]):
@@ -232,13 +231,7 @@ def loadAMatrix(file_name):
 
     with open(file_name, 'rb') as fp:
         
-        # Python 3
-        if (sys.version_info > (3, 0)):
-            matrix = pickle.load(fp, encoding='latin1')
-
-        # Python 2
-        else:
-            matrix = pickle.load(fp)
+        matrix = pickle.load(fp, encoding='latin1')
 
     return matrix
 

--- a/storm_analysis/admm/admm_lasso_c.py
+++ b/storm_analysis/admm/admm_lasso_c.py
@@ -160,7 +160,7 @@ class ADMMLasso(csAlgorithm.CSAlgorithm):
         c_image = numpy.ascontiguousarray(image_no_bg, dtype=numpy.float64)
         admm_lasso.newImage(self.c_admm_lasso, c_image)
 
-    def run(self, a_lamba, iterations):
+    def run(self, a_lambda, iterations):
         admm_lasso.run(self.c_admm_lasso, a_lambda, iterations)
 
 

--- a/storm_analysis/diagnostics/spliner_configure_common.py
+++ b/storm_analysis/diagnostics/spliner_configure_common.py
@@ -23,8 +23,6 @@ import storm_analysis.spliner.measure_psf_beads as measurePSFBeads
 import storm_analysis.spliner.measure_psf_utils as measurePSFUtils
 import storm_analysis.spliner.psf_to_spline as psfToSpline
 
-import storm_analysis.diagnostics.spliner.settings as settings
-
 
 def configure(settings, use_dh, no_splines):
     

--- a/storm_analysis/jupyter_examples/multiplane_measure_psf.py
+++ b/storm_analysis/jupyter_examples/multiplane_measure_psf.py
@@ -221,5 +221,5 @@ if (__name__ == "__main__"):
     makeCMOSCalibration()
     makeMapping()
     makeSampleData()
-    sCMOSSinglePlaneXML()
+    sCMOSSingleFrameXML()
     

--- a/storm_analysis/multi_plane/analysis_io.py
+++ b/storm_analysis/multi_plane/analysis_io.py
@@ -6,7 +6,6 @@ Hazen 09/17
 """
 import numpy
 import os
-import sys
 
 from xml.etree import ElementTree
 
@@ -57,10 +56,7 @@ class MPDataWriter(analysisIO.DataWriter):
             
             # Save analysis parameters.
             etree = parameters.toXMLElementTree(False)
-            if (sys.version_info > (3, 0)):
-                self.h5.addMetadata(ElementTree.tostring(etree, 'unicode'))
-            else:
-                self.h5.addMetadata(ElementTree.tostring(etree, 'ISO-8859-1'))
+            self.h5.addMetadata(ElementTree.tostring(etree, 'unicode'))
 
             # Save pixel size.
             self.h5.setPixelSize(parameters.getAttr("pixel_size"))

--- a/storm_analysis/multi_plane/analysis_io.py
+++ b/storm_analysis/multi_plane/analysis_io.py
@@ -12,6 +12,7 @@ from xml.etree import ElementTree
 
 import storm_analysis.sa_library.analysis_io as analysisIO
 import storm_analysis.sa_library.sa_h5py as saH5Py
+import storm_analysis.sa_library.static_background as static_background
 
 import storm_analysis.multi_plane.mp_utilities as mpUtil
 

--- a/storm_analysis/multi_plane/fitting_mp.py
+++ b/storm_analysis/multi_plane/fitting_mp.py
@@ -600,9 +600,9 @@ class MPPeakFinderDao(MPPeakFinder):
 
             # Save a pictures of the PSFs for debugging purposes.
             if self.check_mode:
-                print("psf max", numpy.max(psf))
-                filename = "psf_z0.0_c{1:d}.tif".format(j)
-                tifffile.imwrite(filename, psf.astype(numpy.float32))
+                print("psf max", numpy.max(psf_norm))
+                filename = "psf_z0.0_c{0:d}.tif".format(i)
+                tifffile.imwrite(filename, psf_norm.astype(numpy.float32))
 
         # This handles the rest of the initialization.
         #

--- a/storm_analysis/multi_plane/mp_fit_arb_c.py
+++ b/storm_analysis/multi_plane/mp_fit_arb_c.py
@@ -103,7 +103,7 @@ class MPPSFFnFit(MPFitArb):
                        "x" : numpy.ones((2, self.n_channels))/float(self.n_channels),
                        "y" : numpy.ones((2, self.n_channels))/float(self.n_channels),
                        "z" : numpy.ones((2, self.n_channels))/float(self.n_channels)}
-            super(MPSFFnFit, self).setWeights(weights, 0.0, 0.0, verbose = verbose)
+            super(MPPSFFnFit, self).setWeights(weights, 0.0, 0.0, verbose = verbose)
 
         else:
             zmax = self.psf_objects[0].getZMax() * 1.0e-3

--- a/storm_analysis/rolling_ball_bgr/rolling_ball_lib_c.py
+++ b/storm_analysis/rolling_ball_bgr/rolling_ball_lib_c.py
@@ -11,7 +11,6 @@ import scipy
 import scipy.ndimage
 
 import ctypes
-import numpy
 from numpy.ctypeslib import ndpointer
 
 import storm_analysis.sa_library.loadclib as loadclib

--- a/storm_analysis/sa_library/analysis_io.py
+++ b/storm_analysis/sa_library/analysis_io.py
@@ -7,7 +7,6 @@ Hazen 09/17
 """
 import numpy
 import os
-import sys
 
 from xml.etree import ElementTree
 
@@ -156,10 +155,7 @@ class DataWriterHDF5(DataWriter):
             
             # Save analysis parameters.
             etree = parameters.toXMLElementTree(False)
-            if (sys.version_info > (3, 0)):
-                self.h5.addMetadata(ElementTree.tostring(etree, 'unicode'))
-            else:
-                self.h5.addMetadata(ElementTree.tostring(etree, 'ISO-8859-1'))
+            self.h5.addMetadata(ElementTree.tostring(etree, 'unicode'))
                 
             # Save pixel size.
             self.h5.setPixelSize(parameters.getAttr("pixel_size"))

--- a/storm_analysis/sa_library/loadclib.py
+++ b/storm_analysis/sa_library/loadclib.py
@@ -44,10 +44,7 @@ def loadCLibrary(library_filename):
             ctypes.windll.kernel32.SetErrorMode(0)
 
             # Push the storm-analysis directory into the DLL search path.
-            if (sys.version_info > (3, 0)):
-                ctypes.windll.kernel32.SetDllDirectoryW(c_lib_path)
-            else:
-                ctypes.windll.kernel32.SetDllDirectoryW(unicode(c_lib_path))
+            ctypes.windll.kernel32.SetDllDirectoryW(c_lib_path)
 
             # Try to load the library.
             c_lib = ctypes.cdll.LoadLibrary(os.path.join(c_lib_path, library_filename))

--- a/storm_analysis/sa_utilities/bin_to_hdf5.py
+++ b/storm_analysis/sa_utilities/bin_to_hdf5.py
@@ -8,7 +8,6 @@ Insight3 file must include metadata.
 Hazen 12/17
 """
 import os
-import sys
 
 from xml.etree import ElementTree
 
@@ -55,10 +54,7 @@ def BinToHDF5(bin_name, hdf5_name):
 
         # Set metadata.
         if params_xml is not None:
-            if (sys.version_info > (3, 0)):
-                h5.addMetadata(ElementTree.tostring(params_xml, 'unicode'))
-            else:
-                h5.addMetadata(ElementTree.tostring(params_xml, 'ISO-8859-1'))
+            h5.addMetadata(ElementTree.tostring(params_xml, 'unicode'))
 
         # Convert data.
         i3 = readinsight3.I3Reader(bin_name)

--- a/storm_analysis/simulator/emitters_on_lines.py
+++ b/storm_analysis/simulator/emitters_on_lines.py
@@ -133,7 +133,7 @@ if (__name__ == "__main__"):
 
     emittersOnLines(args.hdf5,
                     args.nlines,
-                    argls.nemitters,
+                    args.nemitters,
                     sx = args.sx,
                     sy = args.sy,
                     maxl = args.maxl,

--- a/storm_analysis/simulator/pupil_math.py
+++ b/storm_analysis/simulator/pupil_math.py
@@ -184,7 +184,7 @@ class Geometry(object):
         sin_theta_1 = (self.wavelength/self.imm_index)*self.k
         theta_1 = numpy.arcsin(sin_theta_1 + 0j)
 
-        sin_theta_2 = (n1/n2)*sin_theta_1
+        sin_theta_2 = (self.imm_index/smp_index)*sin_theta_1
         theta_2 = numpy.arcsin(sin_theta_2 + 0j)
 
         z_o = smp_index/self.imm_index * z_stage
@@ -206,7 +206,7 @@ class Geometry(object):
         # decrease exponentially with increasing distance from coverslip.
         #
         pf_ab = numpy.exp(-1j * t4)
-        return self.appylNARestriction(pf_ab)
+        return self.applyNARestriction(pf_ab)
 
     def applyNARestriction(self, pupil_fn):
         """

--- a/storm_analysis/spliner/spline1D.py
+++ b/storm_analysis/spliner/spline1D.py
@@ -97,7 +97,7 @@ if (__name__ == "__main__"):
 
     xv = []
     yv = []
-    for i in range(x.size/10):
+    for i in range(x.size//10):
         xv.append(x[i*10])
         yv.append(y[i*10])
     xv.append(x[-1])
@@ -120,5 +120,5 @@ if (__name__ == "__main__"):
     pw.plot(x,ys)
     #pw.plot(x,dxs)
 
-    raw_input("return to continue")
+    input("return to continue")
     

--- a/storm_analysis/test/test_clusters_sa_h5py.py
+++ b/storm_analysis/test/test_clusters_sa_h5py.py
@@ -343,6 +343,8 @@ if (__name__ == "__main__"):
     test_cl_sa_h5py_5()
     test_cl_sa_h5py_6()
     test_cl_sa_h5py_7()
+    test_cl_sa_h5py_z_is_loaded()
+    test_cl_sa_h5py_drops_invalid_z()
 
 
     

--- a/storm_analysis/test/test_drift_correction.py
+++ b/storm_analysis/test/test_drift_correction.py
@@ -480,7 +480,8 @@ def test_drift_correction_10():
 
     
 if (__name__ == "__main__"):
-    _test_drift_correction_1()
+    test_drift_correction_1()
+    test_drift_correction_1_xy_failure()
     test_drift_correction_2()
     test_drift_correction_3()
     test_drift_correction_4()

--- a/storm_analysis/test/test_fitting_mp.py
+++ b/storm_analysis/test/test_fitting_mp.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+"""
+Tests of multi_plane.fitting_mp
+"""
+import glob
+import numpy
+import os
+import pickle
+import tifffile
+
+import storm_analysis
+import storm_analysis.sa_library.fitting as fitting
+import storm_analysis.sa_library.parameters as parameters
+
+import storm_analysis.multi_plane.fitting_mp as fittingMp
+
+
+im_size = (20, 18)
+n_channels = 2
+
+
+def configureTest():
+    """
+    Build the parameters and the mapping file that MPPeakFinderDao needs.
+    """
+    map_name = storm_analysis.getPathOutputTest("test_fitting_mp.map")
+
+    mappings = {}
+    for i in range(n_channels):
+        mappings["0_" + str(i) + "_x"] = numpy.array([0.0, 1.0, 0.0])
+        mappings["0_" + str(i) + "_y"] = numpy.array([0.0, 0.0, 1.0])
+        mappings[str(i) + "_0_x"] = numpy.array([0.0, 1.0, 0.0])
+        mappings[str(i) + "_0_y"] = numpy.array([0.0, 0.0, 1.0])
+    with open(map_name, "wb") as fp:
+        pickle.dump(mappings, fp)
+
+    params = parameters.ParametersMultiplaneDao()
+    params.setAttr("background_sigma", "float", 8.0)
+    params.setAttr("find_max_radius", "int", 2)
+    params.setAttr("foreground_sigma", "float", 1.5)
+    params.setAttr("iterations", "int", 1)
+    params.setAttr("mapping", "filename", map_name)
+    params.setAttr("no_fitting", "int", 0)
+    params.setAttr("pixel_size", "float", 100.0)
+    params.setAttr("roi_size", "int", 10)
+    params.setAttr("sigma", "float", 1.5)
+    params.setAttr("threshold", "float", 6.0)
+
+    return params
+
+
+def test_fitting_mp_check_mode():
+    """
+    MPPeakFinderDao.setVariances() saves a picture of each channel's PSF
+    when check_mode is on.
+
+    That block was copied from the arbitrary PSF version, where the PSF is
+    called 'psf' and the channel index is 'j'. Here the PSF is 'psf_norm'
+    and the index is 'i', so it raised NameError, and the filename kept
+    "{1:d}" from the two argument version, so it would have raised
+    IndexError once the names were fixed.
+    """
+    params = configureTest()
+
+    # check_mode writes into the working directory.
+    cwd = os.getcwd()
+    os.chdir(storm_analysis.getPathOutputTest(""))
+    try:
+        for name in glob.glob("psf_z0.0_c*.tif"):
+            os.remove(name)
+
+        finder = fittingMp.MPPeakFinderDao(parameters = params,
+                                           n_channels = n_channels)
+        finder.check_mode = True
+
+        variances = [numpy.ones(im_size) for i in range(n_channels)]
+        finder.setVariances(variances)
+
+        # One image per channel, named by the channel index.
+        written = sorted(glob.glob("psf_z0.0_c*.tif"))
+        assert(written == ["psf_z0.0_c0.tif", "psf_z0.0_c1.tif"])
+
+        # And it is the normalized PSF that was saved, computed here
+        # independently of the finder. The variances are padded by the
+        # margin before the filters are built.
+        padded = (im_size[0] + 2*finder.margin, im_size[1] + 2*finder.margin)
+        expected = fitting.gaussianPSF(padded, 1.5).astype(numpy.float32)
+
+        for name in written:
+            psf = tifffile.imread(name)
+            assert(psf.shape == padded)
+            assert(numpy.allclose(psf, expected))
+    finally:
+        os.chdir(cwd)
+
+
+if (__name__ == "__main__"):
+    test_fitting_mp_check_mode()

--- a/storm_analysis/test/test_fitz_c.py
+++ b/storm_analysis/test/test_fitz_c.py
@@ -271,4 +271,6 @@ if (__name__ == "__main__"):
     test_fitz_c_3()
     test_fitz_c_4()
     test_fitz_c_5()
+    test_fitz_c_marker_survives_drift()
+    test_fitz_c_marker_propagates_to_tracks()
     

--- a/storm_analysis/test/test_pupil_math.py
+++ b/storm_analysis/test/test_pupil_math.py
@@ -82,9 +82,51 @@ def test_pupil_math_5():
     psf_c = geo_c.pfToPSF(pf, z_vals, scaling_factor = gsf)
     
     
+def test_pupil_math_aberration_opd():
+    """
+    aberrationOPD() had two names wrong and could not run at all.
+
+    sin_theta_2 was computed from n1 and n2, neither of which exists, and
+    the return statement called self.appylNARestriction(). The first
+    raised NameError, and fixing only that moved the failure to an
+    AttributeError from the second.
+
+    Snell's law here is between the immersion medium and the sample,
+    which is what the sibling aberration() uses:
+
+        sin_theta_2 = (self.imm_index/smp_index)*sin_theta_1
+
+    This geometry deliberately puts most of the grid outside the NA, so
+    that the restriction being applied is observable rather than vacuous.
+    """
+    geo = pupilMath.Geometry(32, 0.05, 0.6, 1.5, 1.2)
+
+    # applyNARestriction() masks on the normalized radius, geo.r > 1.0.
+    # geo.r_max is a different quantity, the NA edge in grid units.
+    outside = (geo.r > 1.0)
+    assert(numpy.count_nonzero(outside) > 0)
+
+    ab = geo.aberrationOPD(1.0, 0.5, 1.33)
+
+    assert(ab.shape == (32, 32))
+    assert(numpy.all(numpy.isfinite(ab)))
+
+    # applyNARestriction() zeros everything beyond the NA.
+    assert(numpy.all(ab[outside] == 0.0))
+    assert(numpy.any(ab[~outside] != 0.0))
+
+    # At zero defocus and a matched sample index there is no aberration,
+    # so the function is identically 1 inside the NA.
+    flat = geo.aberrationOPD(0.0, 0.0, 1.5)
+    assert(numpy.allclose(flat[~outside], 1.0 + 0j))
+
+
 if (__name__ == "__main__"):
     test_pupil_math_1()
     test_pupil_math_2()
     test_pupil_math_3()
+    test_pupil_math_4()
+    test_pupil_math_5()
+    test_pupil_math_aberration_opd()
 
     

--- a/storm_analysis/test/test_simulator.py
+++ b/storm_analysis/test/test_simulator.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 import numpy
-import sys
 import tifffile
 
 import storm_analysis
@@ -20,10 +19,6 @@ def test_psf_spline2D_1():
     """
     Test that spline PSF agrees with spliner (for 0.0 offset).
     """
-    # Only test for Python3 due to pickle incompatibility issues.
-    if (sys.version_info < (3, 0)):
-        return
-    
     spline_name = storm_analysis.getData("test/data/test_spliner_psf_2d.spline")
         
     psf_sp_2d = psf.Spline2D(spline_name)
@@ -39,10 +34,6 @@ def test_psf_spline2D_2():
     """
     Test that spline PSF C and Python versions agree.
     """
-    # Only test for Python3 due to pickle incompatibility issues.
-    if (sys.version_info < (3, 0)):
-        return
-    
     spline_name = storm_analysis.getData("test/data/test_spliner_psf_2d.spline")
         
     psf_sp_2D = psf.Spline2D(spline_name)
@@ -60,10 +51,6 @@ def test_psf_spline3D_1():
     """
     Test that spline PSF agrees with spliner (for 0.0 offset).
     """
-    # Only test for Python3 due to pickle incompatibility issues.
-    if (sys.version_info < (3, 0)):
-        return
-    
     spline_name = storm_analysis.getData("test/data/test_spliner_psf.spline")
         
     psf_sp_3d = psf.Spline3D(spline_name)
@@ -79,10 +66,6 @@ def test_psf_spline3D_2():
     """
     Test that spline PSF C and Python versions agree.
     """
-    # Only test for Python3 due to pickle incompatibility issues.
-    if (sys.version_info < (3, 0)):
-        return
-    
     spline_name = storm_analysis.getData("test/data/test_spliner_psf.spline")
         
     psf_sp_3D = psf.Spline3D(spline_name)
@@ -133,10 +116,6 @@ def test_simulate_3():
     """
     No photo-physics, spline PSF, sCMOS camera.
     """
-    
-    # Only test for Python3 due to pickle incompatibility issues.
-    if (sys.version_info < (3, 0)):
-        return
     
     dax_name = storm_analysis.getPathOutputTest("test_sim3.dax")
     bin_name = storm_analysis.getData("test/data/test_sim.hdf5")

--- a/storm_analysis/test/test_spline.py
+++ b/storm_analysis/test/test_spline.py
@@ -5,7 +5,6 @@ Tests of splines.
 import numpy
 import pickle
 import random
-import sys
 
 import storm_analysis
 
@@ -18,12 +17,6 @@ reps = 1000
 
 def test_psf_2D_f():
 
-    # Only test for Python3 due to pickle incompatibility issues which I am tired
-    # of trying to deal with.
-    #
-    if (sys.version_info < (3, 0)):
-        return
-    
     spline_filename = storm_analysis.getData("test/data/test_spliner_psf_2d.spline")
     with open(spline_filename, "rb") as fp:
         spline_data = pickle.load(fp)
@@ -41,10 +34,6 @@ def test_psf_2D_f():
 
 def test_psf_2D_dx():
 
-    # Only test for Python3 due to pickle incompatibility issues.
-    if (sys.version_info < (3, 0)):
-        return
-    
     spline_filename = storm_analysis.getData("test/data/test_spliner_psf_2d.spline")
     with open(spline_filename, "rb") as fp:
         spline_data = pickle.load(fp)
@@ -62,10 +51,6 @@ def test_psf_2D_dx():
 
 def test_psf_2D_dy():
 
-    # Only test for Python3 due to pickle incompatibility issues.
-    if (sys.version_info < (3, 0)):
-        return
-    
     spline_filename = storm_analysis.getData("test/data/test_spliner_psf_2d.spline")
     with open(spline_filename, "rb") as fp:
         spline_data = pickle.load(fp)
@@ -84,10 +69,6 @@ def test_psf_2D_dy():
 
 def test_psf_3D_f():
 
-    # Only test for Python3 due to pickle incompatibility issues.
-    if (sys.version_info < (3, 0)):
-        return
-    
     spline_filename = storm_analysis.getData("test/data/test_spliner_psf.spline")
     with open(spline_filename, "rb") as fp:
         spline_data = pickle.load(fp)
@@ -106,10 +87,6 @@ def test_psf_3D_f():
 
 def test_psf_3D_dx():
 
-    # Only test for Python3 due to pickle incompatibility issues.
-    if (sys.version_info < (3, 0)):
-        return
-    
     spline_filename = storm_analysis.getData("test/data/test_spliner_psf.spline")
     with open(spline_filename, "rb") as fp:
         spline_data = pickle.load(fp)
@@ -128,10 +105,6 @@ def test_psf_3D_dx():
 
 def test_psf_3D_dy():
 
-    # Only test for Python3 due to pickle incompatibility issues.
-    if (sys.version_info < (3, 0)):
-        return
-    
     spline_filename = storm_analysis.getData("test/data/test_spliner_psf.spline")
     with open(spline_filename, "rb") as fp:
         spline_data = pickle.load(fp)
@@ -150,10 +123,6 @@ def test_psf_3D_dy():
 
 def test_psf_3D_dz():
 
-    # Only test for Python3 due to pickle incompatibility issues.
-    if (sys.version_info < (3, 0)):
-        return
-    
     spline_filename = storm_analysis.getData("test/data/test_spliner_psf.spline")
     with open(spline_filename, "rb") as fp:
         spline_data = pickle.load(fp)
@@ -178,8 +147,6 @@ def test_psf_2D_py_f():
     the opposite order, which evaluates the transposed point. A PSF spline is
     not symmetric in x and y, so the answers differ.
     """
-    if (sys.version_info < (3, 0)):
-        return
 
     spline_filename = storm_analysis.getData("test/data/test_spliner_psf_2d.spline")
     with open(spline_filename, "rb") as fp:
@@ -200,8 +167,6 @@ def test_psf_3D_py_f():
     The same check on CSpline3D, which has always passed its arguments
     through in the right order.
     """
-    if (sys.version_info < (3, 0)):
-        return
 
     spline_filename = storm_analysis.getData("test/data/test_spliner_psf.spline")
     with open(spline_filename, "rb") as fp:

--- a/storm_analysis/test/test_spliner.py
+++ b/storm_analysis/test/test_spliner.py
@@ -4,7 +4,6 @@ Tests for Spliner analysis.
 """
 import numpy
 import pickle
-import sys
 
 import storm_analysis
 
@@ -73,10 +72,6 @@ def test_psf_to_spline_2D():
     
 def test_spliner_std():
 
-    # Only test for Python3 due to pickle incompatibility issues.
-    if (sys.version_info < (3, 0)):
-        return
-                    
     movie_name = storm_analysis.getData("test/data/test_spliner.dax")
     settings = storm_analysis.getData("test/data/test_spliner_dh.xml")
     mlist = storm_analysis.getPathOutputTest("test_spliner_dh.hdf5")
@@ -92,10 +87,6 @@ def test_spliner_std():
 
 
 def test_spliner_std_2D():
-
-    # Only test for Python3 due to pickle incompatibility issues.
-    if (sys.version_info < (3, 0)):
-        return
 
     movie_name = storm_analysis.getData("test/data/test.dax")
     settings = storm_analysis.getData("test/data/test_spliner_2D.xml")
@@ -113,10 +104,6 @@ def test_spliner_std_2D():
     
 def test_spliner_std_non_square():
 
-    # Only test for Python3 due to pickle incompatibility issues.
-    if (sys.version_info < (3, 0)):
-        return
-    
     movie_name = storm_analysis.getData("test/data/test_300x200_dh.dax")
     settings = storm_analysis.getData("test/data/test_spliner_dh.xml")
     mlist = storm_analysis.getPathOutputTest("test_spliner_dh.hdf5")
@@ -133,9 +120,6 @@ def test_spliner_std_non_square():
 
 def test_spliner_fista():
 
-    # Only test for Python3 due to pickle incompatibility issues.
-    if (sys.version_info < (3, 0)):
-        return    
 
     movie_name = storm_analysis.getData("test/data/test_spliner.dax")
     settings = storm_analysis.getData("test/data/test_spliner_dh_fista.xml")
@@ -153,10 +137,6 @@ def test_spliner_fista():
 
 def test_spliner_fista_2D():
 
-    # Only test for Python3 due to pickle incompatibility issues.
-    if (sys.version_info < (3, 0)):
-        return
-    
     movie_name = storm_analysis.getData("test/data/test.dax")
     settings = storm_analysis.getData("test/data/test_spliner_2D_fista.xml")
     mlist = storm_analysis.getPathOutputTest("test_spliner_2D_fista.hdf5")
@@ -173,10 +153,6 @@ def test_spliner_fista_2D():
 
 def test_spliner_fista_non_square():
 
-    # Only test for Python3 due to pickle incompatibility issues.
-    if (sys.version_info < (3, 0)):
-        return
-    
     movie_name = storm_analysis.getData("test/data/test_300x200_dh.dax")
     settings = storm_analysis.getData("test/data/test_spliner_dh_fista.xml")
     mlist = storm_analysis.getPathOutputTest("test_spliner_dh_fista_ns.hdf5")

--- a/storm_analysis/test/test_spliner.py
+++ b/storm_analysis/test/test_spliner.py
@@ -194,8 +194,8 @@ def test_spliner_fista_non_square():
 if (__name__ == "__main__"):
     test_measure_psf()
     test_measure_psf_2D()
-#    _test_psf_to_spline()
-#    _test_psf_to_spline_2D()
+    test_psf_to_spline()
+    test_psf_to_spline_2D()
     test_spliner_std()
     test_spliner_std_2D()
     test_spliner_std_non_square()


### PR DESCRIPTION
Ruff (`--select F`, the pyflakes rules) reports 486 findings. This fixes the
ones that mean "this raises if the path runs", plus the Python 2 code that
several of them turn out to be.

None of these paths is covered by the test suite, which is how they survived.

### The crash class

| where | what |
| --- | --- |
| `simulator/pupil_math.py` | `sin_theta_2 = (n1/n2)*sin_theta_1` — neither name exists |
| `multi_plane/fitting_mp.py` | `psf` and `j` undefined, and `"...c{1:d}".format(j)` passes one argument for index 1 |
| `multi_plane/analysis_io.py` | `static_background` used but never imported |
| `admm/admm_lasso_c.py` | `def run(self, a_lamba, ...)` against a body using `a_lambda` |
| `multi_plane/mp_fit_arb_c.py` | `super(MPSFFnFit, ...)` inside `class MPPSFFnFit` |
| `simulator/emitters_on_lines.py` | `argls.nemitters` for `args.nemitters` |
| `jupyter_examples/multiplane_measure_psf.py` | `__main__` calls `sCMOSSinglePlaneXML()`; it is `sCMOSSingleFrameXML()` |
| `test/test_drift_correction.py` | `__main__` calls `_test_drift_correction_1()`, renamed in #59 |

Plus two things defined twice: `rolling_ball_lib_c.py` imports numpy twice,
and `spliner_configure_common.py` imports spliner's settings module and then
shadows it with `configure()`'s parameter — which matters because
`fista_decon/configure.py` calls that function with its own settings.

**Two of these needed a second fix the linter cannot see.** `pupil_math.py`
also calls `self.appylNARestriction()` — an attribute, not a bare name, so
pyflakes' rules do not reach it, and fixing only the `NameError` moves the
failure four lines down. `fitting_mp.py` likewise would have gone from
`NameError` to `IndexError` on the format string. Both were caught only by
writing a test that actually calls the code.

### Tests

`test_fitting_mp.py` is new — there was no test file for that module. It
builds the multiplane finder, turns `check_mode` on and reaches the block,
then checks the written TIFFs against a Gaussian PSF computed independently
in the test. The `pupil_math` test uses a geometry chosen so that 691 of 1024
pixels fall outside the NA; at the geometry the other tests in that file use,
nothing does, and the NA assertion would pass while testing nothing.

### Python 2

`pyproject.toml` already declares `requires-python = '>=3.10'` and CI builds
3.10 through 3.12, so the 25 `sys.version_info` guards were dead code rather
than a supported path. Removed, along with the seven `import sys` statements
that became unused as a result, and the two Python 2 idioms in `spline1D.py`'s
demo block.

### Deliberately not done

- `TSFProto_pb2.py` keeps its two `unicode` calls. It is generated protobuf
  output marked "DO NOT EDIT", `google.protobuf` is not a dependency, and its
  two consumers use the Python 2 implicit relative `import TSFProto_pb2`.
  Those three files do not run at all; untangling them is a separate job.
  These are the only `F821` findings left in the tree, down from 19.
- The other 462 findings, almost all unused imports and variables. Fixing
  them means rewriting files wholesale for no functional gain, which deserves
  its own decision rather than riding along here.

---

Full test suite passes, 280 tests. The four test files whose `__main__`
blocks changed were also run directly, since that is the path pytest never
executes and therefore never checked.
