### PR TITLE
Add a headless mode for running without a display

### DIFF
--- a/storm_analysis/__init__.py
+++ b/storm_analysis/__init__.py
@@ -4,11 +4,38 @@ Some miscellaneous functions, mostly used for testing.
 """
 import os
 import matplotlib
+
+#
+# Headless operation.
+#
+# Setting STORM_ANALYSIS_HEADLESS in the environment selects a
+# non-interactive matplotlib backend, which makes every pyplot.show() in
+# the package a no-op. Nothing can then open a window and block, which is
+# what you want when running the diagnostics, or anything else, without
+# someone sitting there to close the windows.
+#
+# This has to happen before pyplot is imported, hence its position here.
+# Saving figures is not affected, savefig() works the same under Agg.
+#
+if os.environ.get("STORM_ANALYSIS_HEADLESS"):
+    matplotlib.use("Agg")
+
 import matplotlib.pyplot as pyplot
 
 
 class SAException(Exception):
     pass
+
+
+def isHeadless():
+    """
+    Return True if we were asked not to open any plot windows.
+
+    Note that this reports the request, not the outcome. matplotlib will
+    also fall back to a non-interactive backend on its own when there is
+    no display available.
+    """
+    return bool(os.environ.get("STORM_ANALYSIS_HEADLESS"))
 
 __version__ = "2026.08.30"
 

--- a/storm_analysis/diagnostics/README.txt
+++ b/storm_analysis/diagnostics/README.txt
@@ -21,6 +21,21 @@ changing (1) and (3) as needed, to test analysis performance with different type
 simulated data.
 
 
+Running without a display:
+
+Some of the analysis these call will open a plot window and wait for you to close
+it, which is not what you want when running several diagnostics in a row. Setting
+
+  STORM_ANALYSIS_HEADLESS=1
+
+in the environment selects a non-interactive matplotlib backend, so pyplot.show()
+does nothing anywhere in the package. Figures that are written to disk, such as the
+mapping images from the multicolor diagnostic, are still written.
+
+Note that multiplane/configure.py needs --psf-model, one of psf_fft, pupilfn or
+spline. The rest take no arguments.
+
+
 (Linux) C profiling tools:
 1. http://valgrind.org/docs/manual/cl-manual.html
 2. http://kcachegrind.sourceforge.net/html/Home.html

--- a/storm_analysis/diagnostics/frc/analyze_data.py
+++ b/storm_analysis/diagnostics/frc/analyze_data.py
@@ -22,7 +22,9 @@ def analyzeData():
         frc_text = os.path.join(a_dir, "frc.txt")
 
         # Run FRC analysis.
-        frcCalc2d.frcCalc2d(hdf5, frc_text)
+        # show_plot defaults to True, and this loops over every test
+        # directory, so without this it stops on a window each time.
+        frcCalc2d.frcCalc2d(hdf5, frc_text, show_plot = False)
 
     print()
 


### PR DESCRIPTION
Running the diagnostics one after another stops on a plot window.
`frc/frc_calc2d.py` has `show_plot = True` by default and
`diagnostics/frc/analyze_data.py` calls it without saying otherwise, once per
test directory. Its command line already has `--no-plot`; only the
programmatic call was missing the equivalent.

Two changes, because the immediate cause and the general one are different.

### The call site

`diagnostics/frc/analyze_data.py` now passes `show_plot = False`. An analyze
step that loops over directories should never wait for someone to close a
window.

### The general case

`STORM_ANALYSIS_HEADLESS` in the environment now selects a non-interactive
matplotlib backend, set in `__init__.py` before `pyplot` is imported. That
makes every `pyplot.show()` in the package a no-op — all 21 of them — without
touching a single call site.

Worth having because the flags controlling this are not consistent:

| module | flag | note |
| --- | --- | --- |
| `frc/frc_calc2d.py` | `show_plot` | defaults to True |
| `multi_plane/plane_weighting.py` | `no_plots` | inverted sense |
| `rcc/rcc_drift_correction.py` | `make_plots` | |
| `micrometry/micrometry.py` | `show`, `save_as` | |

Four flags, three spellings, one inverted. Anyone adding a diagnostic has to
know which applies, and getting it wrong produces a hung script rather than an
error.

### Figures written to disk are unaffected

`savefig()` works the same under Agg. Checked rather than assumed: directly,
and by re-running the multicolor diagnostic headless and confirming it still
produces its three mapping images.

Verified that the default is unchanged (`tkagg` here), that with the variable
set the backend is `Agg` and `show()` returns instead of blocking, and that
the frc diagnostic's analyze step drops from 9s to 2s because it no longer
builds the figure.

Also adds `isHeadless()`, for code that would rather skip building a figure it
cannot display.

The diagnostics README says how to use it, and — while there — that
`multiplane/configure.py` needs `--psf-model`, which is the one thing in that
directory you cannot work out from the README.

---

Full test suite passes, 280 tests. All 17 diagnostics were then run end to
end with this branch, 68 steps, no failures; multiplane was run three times,
once per PSF model.
